### PR TITLE
Feat: 페이지별 메타데이터 추가 및 i18n localePath 추가

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,6 +1,9 @@
+const path = require("path");
+
 module.exports = {
   i18n: {
     locales: ["ko", "en"],
     defaultLocale: "ko",
+    localePath: path.resolve("./public/locales"),
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "next": "14.2.4",
         "next-auth": "^4.24.8",
         "next-i18next": "^15.3.1",
+        "next-seo": "^6.6.0",
         "react": "^18",
         "react-dom": "^18",
         "react-error-boundary": "^4.0.13",
@@ -6690,6 +6691,16 @@
         "next": ">= 12.0.0",
         "react": ">= 17.0.2",
         "react-i18next": ">= 13.5.0"
+      }
+    },
+    "node_modules/next-seo": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/next-seo/-/next-seo-6.6.0.tgz",
+      "integrity": "sha512-0VSted/W6XNtgAtH3D+BZrMLLudqfm0D5DYNJRXHcDgan/1ZF1tDFIsWrmvQlYngALyphPfZ3ZdOqlKpKdvG6w==",
+      "peerDependencies": {
+        "next": "^8.1.1-canary.54 || >=9.0.0",
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next": "14.2.4",
     "next-auth": "^4.24.8",
     "next-i18next": "^15.3.1",
+    "next-seo": "^6.6.0",
     "react": "^18",
     "react-dom": "^18",
     "react-error-boundary": "^4.0.13",

--- a/src/pages/artist/[artistId].tsx
+++ b/src/pages/artist/[artistId].tsx
@@ -7,6 +7,7 @@ import axios from "axios";
 import { GetServerSideProps } from "next";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { NextSeo } from "next-seo";
 import Link from "next/link";
 
 interface ArtistPageProps {
@@ -70,6 +71,29 @@ const ArtistPage = ({ artistId }: ArtistPageProps) => {
 
   return (
     <div className="max-w-4xl mx-auto p-6 mt-8 bg-zinc-800 rounded-lg shadow-md">
+      <NextSeo
+        title={`Track List Now - ${artist.name}`}
+        description={`Basic Information, Top tracks, Related artists of ${artist.name}`}
+        openGraph={{
+          type: "music.artist",
+          url: `https://www.tracklistnow.com/artist/${artistId}`,
+          title: `Track List Now - ${artist.name}`,
+          description: `Discover more about ${artist.name} on Track List Now!`,
+          images: [
+            {
+              url: artist.images[0]?.url || "/default-image.jpg",
+              width: 800,
+              height: 800,
+              alt: `${artist.name} Profile Picture`,
+            },
+          ],
+        }}
+        twitter={{
+          handle: "@TrackListNow",
+          site: "@TrackListNow",
+          cardType: "summary_large_image",
+        }}
+      />
       {/* 아티스트 기본 정보 */}
       <div className="flex flex-col items-center">
         <div className="relative w-[300px] h-[300px] rounded-full overflow-hidden">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,7 @@ import axios from "axios";
 import { GetServerSideProps } from "next";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { NextSeo } from "next-seo";
 
 type RankingCategory =
   | "ALL_TIME_ARTIST"
@@ -123,6 +124,30 @@ const MainPage = () => {
 
   return (
     <div className="max-w-5xl mx-auto p-6 grid grid-cols-1 md:grid-cols-2 gap-8">
+      <NextSeo
+        title="Track List Now"
+        description="Explore the top-ranked artists and tracks, featuring all-time favorites and current trends on Track List Now."
+        openGraph={{
+          type: "website",
+          url: "https://www.tracklistnow.com",
+          title: "Track List Now",
+          description:
+            "Explore the top-ranked artists and tracks, featuring all-time favorites and current trends on Track List Now.",
+          images: [
+            {
+              url: "/default-image.jpg",
+              width: 800,
+              height: 600,
+              alt: "Track List Now",
+            },
+          ],
+        }}
+        twitter={{
+          handle: "@TrackListNow",
+          site: "@TrackListNow",
+          cardType: "summary_large_image",
+        }}
+      />
       {sections.map((section) => (
         <RankingSection
           key={section.category}

--- a/src/pages/profile/[userId].tsx
+++ b/src/pages/profile/[userId].tsx
@@ -7,6 +7,7 @@ import { GetServerSideProps } from "next";
 import { getSession, useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { NextSeo } from "next-seo";
 import Image from "next/image";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -37,6 +38,7 @@ interface ProfilePageProps {
   viewedUserName: string;
   profileImage: string | null;
   isOwnProfile: boolean;
+  userId: number;
 }
 
 const isArtist = (
@@ -63,6 +65,7 @@ const ProfilePage = ({
   viewedUserName,
   profileImage,
   isOwnProfile,
+  userId,
 }: ProfilePageProps) => {
   const { t } = useTranslation(["common", "profile"]);
   const { data: session } = useSession();
@@ -197,6 +200,29 @@ const ProfilePage = ({
 
   return (
     <div className="max-w-3xl mx-auto text-white">
+      <NextSeo
+        title={`Track List Now - ${viewedUserName}`}
+        description={`${viewedUserName}'s favorite artists and tracks on Track List Now`}
+        openGraph={{
+          type: "profile",
+          url: `https://www.tracklistnow.com/profile/${userId}`,
+          title: `Track List Now - ${viewedUserName}`,
+          description: `${viewedUserName}'s favorite artists and tracks`,
+          images: [
+            {
+              url: profileImage || "/default-profile-image.jpg",
+              width: 800,
+              height: 800,
+              alt: `${viewedUserName}'s Profile Image`,
+            },
+          ],
+        }}
+        twitter={{
+          handle: "@TrackListNow",
+          site: "@TrackListNow",
+          cardType: "summary_large_image",
+        }}
+      />
       <div ref={pageRef} className="p-6">
         {isOwnProfile ? (
           <div className="flex flex-col gap-4 text-center mb-4">
@@ -319,7 +345,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/users?userId=${userId}`,
     );
     const { name: viewedUserName, profileImage } = userResponse.data;
-    const isOwnProfile = session?.user?.id === userId;
+    const isOwnProfile = JSON.stringify(session?.user?.id) === userId;
 
     return {
       props: {
@@ -328,6 +354,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         viewedUserName,
         profileImage,
         isOwnProfile,
+        userId,
       },
     };
   } catch (error) {
@@ -346,6 +373,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         viewedUserName: "Unknown User",
         profileImage: null,
         isOwnProfile: false,
+        userId: 0,
       },
     };
   }

--- a/src/pages/ranking/[category].tsx
+++ b/src/pages/ranking/[category].tsx
@@ -8,6 +8,7 @@ import axios from "axios";
 import { GetServerSideProps } from "next";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { NextSeo } from "next-seo";
 
 type RankingCategory =
   | "ALL_TIME_ARTIST"
@@ -128,8 +129,34 @@ const RankingPage = ({ category }: RankingPageProps) => {
       break;
   }
 
+  const pageTitle = t(title);
+  const pageDescription = `Top ${sectionType === "artist" ? "Artists" : "Tracks"} ranking for ${pageTitle.replace("_", " ")} on Track List Now`;
+
   return (
     <div className="max-w-5xl mx-auto p-6 mt-8">
+      <NextSeo
+        title={`Track List Now - ${pageTitle}`}
+        description={pageDescription}
+        openGraph={{
+          type: "website",
+          url: `https://www.tracklistnow.com/ranking/${category.toLowerCase()}`,
+          title: `Track List Now - ${pageTitle}`,
+          description: pageDescription,
+          images: [
+            {
+              url: "/default-image.jpg",
+              width: 800,
+              height: 600,
+              alt: "Track List Now",
+            },
+          ],
+        }}
+        twitter={{
+          handle: "@TrackListNow",
+          site: "@TrackListNow",
+          cardType: "summary_large_image",
+        }}
+      />
       <h1 className="text-3xl font-bold text-white mb-6">{t(title)}</h1>
       {sectionData.length === 0 ? (
         <p className="text-gray-400 text-center mt-4">{t("no_data")}</p>

--- a/src/pages/track/[trackId].tsx
+++ b/src/pages/track/[trackId].tsx
@@ -6,6 +6,7 @@ import axios from "axios";
 import { GetServerSideProps } from "next";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { NextSeo } from "next-seo";
 import Image from "next/image";
 import Link from "next/link";
 import { useRef } from "react";
@@ -45,8 +46,34 @@ const TrackPage = ({ trackId }: TrackPageProps) => {
     return <div className="text-center text-gray-400">{t("no_data")}</div>;
   }
 
+  const trackTitle = track.name;
+  const artistNames = track.artists.map((artist) => artist.name).join(", ");
+
   return (
     <div className="max-w-4xl mx-auto p-6 mt-8 bg-zinc-800 rounded-lg shadow-md">
+      <NextSeo
+        title={`Track List Now - ${trackTitle}`}
+        description={`Listen to ${trackTitle} by ${artistNames}. Find information about the album, release date, and duration.`}
+        openGraph={{
+          type: "music.song",
+          url: `https://www.tracklistnow.com/track/${trackId}`,
+          title: `Track List Now - ${trackTitle}`,
+          description: `Listen to ${trackTitle} by ${artistNames}. Find information about the album, release date, and duration.`,
+          images: [
+            {
+              url: track.album.images[0]?.url || "/default-image.jpg",
+              width: 800,
+              height: 800,
+              alt: `${trackTitle} Album Cover`,
+            },
+          ],
+        }}
+        twitter={{
+          handle: "@TrackListNow",
+          site: "@TrackListNow",
+          cardType: "summary_large_image",
+        }}
+      />
       <div className="flex flex-col items-center">
         <Image
           src={track.album.images[0]?.url || "/default-image.jpg"}


### PR DESCRIPTION
1. [Feat: 페이지별 메타데이터 추가 및 i18n localePath 추가](https://github.com/jihohub/track-list-now/commit/1956133005122180785824c2a475b1d2fe1ab97d)