### PR TITLE
Feat: SearchResultItem 컴포넌트 내 Link 컴포넌트에 css 속성 적용

### DIFF
--- a/src/features/search/SearchResultItem.tsx
+++ b/src/features/search/SearchResultItem.tsx
@@ -44,7 +44,11 @@ const SearchResultItem = ({ result, listType }: SearchResultItemProps) => {
 
   return (
     <li className="flex items-center justify-between text-sm text-white cursor-pointer bg-zinc-900 hover:bg-gray-700 p-2 rounded-lg">
-      <Link href={getDetailPageUrl()} passHref>
+      <Link
+        href={getDetailPageUrl()}
+        passHref
+        className="flex justify-between items-center w-full"
+      >
         <div className="flex items-center">
           <TImage
             imageUrl={


### PR DESCRIPTION
1. [Feat: SearchResultItem 컴포넌트 내 Link 컴포넌트에 css 속성 적용](https://github.com/jihohub/track-list-now/commit/b47b06a5051623e3a6159d7b8d893b2156983030)