### PR TITLE
Feat: 프로필 페이지 데이터 페칭 커스텀훅 추가, 스켈레톤UI 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "html-to-image": "^1.11.11",
         "html2canvas": "^1.4.1",
         "i18next": "^23.15.1",
+        "modern-screenshot": "^4.4.39",
         "next": "14.2.4",
         "next-auth": "^4.24.10",
         "next-i18next": "^15.3.1",
@@ -6333,6 +6334,11 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/modern-screenshot": {
+      "version": "4.4.39",
+      "resolved": "https://registry.npmjs.org/modern-screenshot/-/modern-screenshot-4.4.39.tgz",
+      "integrity": "sha512-p+I4yLZUDnoJMa5zoi+71nLQmoLQ6WRU4W8vZu1BZk2PlIYOz5mGnj9/7t2lGWKYeOr4zo6pajhY0/9TS5Zcdw=="
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "html-to-image": "^1.11.11",
     "html2canvas": "^1.4.1",
     "i18next": "^23.15.1",
+    "modern-screenshot": "^4.4.39",
     "next": "14.2.4",
     "next-auth": "^4.24.10",
     "next-i18next": "^15.3.1",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 const Footer = () => (
-  <footer className="bg-zinc-950 text-vividSkyBlue p-4 mt-auto">
+  <footer className="md:block hidden bg-zinc-950 text-vividSkyBlue p-4 mt-auto">
     <div className="container mx-auto text-center">
       <p>&copy; 2024 Track List Now. All rights reserved.</p>
     </div>

--- a/src/features/common/GlobalLoadingBar.tsx
+++ b/src/features/common/GlobalLoadingBar.tsx
@@ -1,19 +1,8 @@
 import LoadingBar from "@/features/common/LoadingBar";
-import { useIsFetching, useIsMutating } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import useGlobalLoading from "@/hooks/useGlobalLoading";
 
 const GlobalLoadingBar = () => {
-  const isFetching = useIsFetching();
-  const isMutating = useIsMutating();
-  const [isLoading, setIsLoading] = useState(false);
-
-  useEffect(() => {
-    if (isFetching > 0 || isMutating > 0) {
-      setIsLoading(true);
-    } else {
-      setIsLoading(false);
-    }
-  }, [isFetching, isMutating]);
+  const isLoading = useGlobalLoading();
 
   return isLoading ? <LoadingBar /> : null;
 };

--- a/src/features/main/RankingSection.tsx
+++ b/src/features/main/RankingSection.tsx
@@ -3,6 +3,7 @@ import { convertToURL } from "@/libs/utils/categoryMapper";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
 
+import useGlobalLoading from "@/hooks/useGlobalLoading";
 import {
   RankingSectionProps,
   isArtistWithRanking,
@@ -16,6 +17,7 @@ const RankingSection = ({
   category,
 }: RankingSectionProps) => {
   const { t } = useTranslation(["common", "main"]);
+  const isLoading = useGlobalLoading();
   const categoryURL = convertToURL(category);
 
   return (
@@ -23,7 +25,7 @@ const RankingSection = ({
       <div className="flex-grow">
         <h2 className="text-2xl text-white font-bold mb-4">{title}</h2>
         <ul>
-          {data.length === 0 ? (
+          {!isLoading && data.length === 0 ? (
             <li className="flex justify-center items-center h-[280px]">
               <p className="text-gray-400 text-center">{t("no_data")}</p>
             </li>

--- a/src/features/profile/EditControls.tsx
+++ b/src/features/profile/EditControls.tsx
@@ -1,0 +1,28 @@
+interface EditControlsProps {
+  label: string;
+  isEditing: boolean;
+  toggleEditing: () => void;
+  handleSaveChanges: () => void;
+}
+
+const EditControls = ({
+  label,
+  isEditing,
+  toggleEditing,
+  handleSaveChanges,
+}: EditControlsProps) => {
+  return (
+    <div className="flex justify-end mb-6">
+      <button
+        onClick={isEditing ? handleSaveChanges : toggleEditing}
+        className="bg-persianBlue text-white px-4 py-2 rounded-lg"
+        type="button"
+        aria-label={isEditing ? "Save Changes" : "Edit Profile"}
+      >
+        {label}
+      </button>
+    </div>
+  );
+};
+
+export default EditControls;

--- a/src/features/profile/FavoriteSectionSkeleton.tsx
+++ b/src/features/profile/FavoriteSectionSkeleton.tsx
@@ -1,0 +1,18 @@
+const FavoriteSectionSkeleton = () => {
+  return (
+    <div className="bg-zinc-800 p-6 rounded-lg shadow-md animate-pulse mb-8">
+      <div className="h-6 bg-gray-500 rounded mb-4 w-1/3"></div>
+      <div className="grid grid-cols-3 gap-4">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="flex flex-col items-center">
+            <div
+              className={`w-24 h-24 bg-gray-500 ${index % 2 === 0 ? "rounded-full" : "rounded-lg"}`}
+            ></div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default FavoriteSectionSkeleton;

--- a/src/features/profile/FavoriteSections.tsx
+++ b/src/features/profile/FavoriteSections.tsx
@@ -1,0 +1,51 @@
+import FavoriteSection from "@/features/profile/FavoriteSection";
+import FavoriteSectionSkeleton from "@/features/profile/FavoriteSectionSkeleton";
+import { UserFavorites } from "@/types/favorite";
+
+interface SectionConfig {
+  title: string;
+  items: UserFavorites[keyof UserFavorites];
+  type: "artist" | "track";
+  openModal: () => void;
+  handleDelete: (id: string) => void;
+}
+
+interface FavoriteSectionsProps {
+  sections: SectionConfig[];
+  isEditing: boolean;
+  isLoading?: boolean;
+}
+
+const FavoriteSections: React.FC<FavoriteSectionsProps> = ({
+  sections,
+  isEditing,
+  isLoading = false,
+}) => {
+  if (isLoading) {
+    return (
+      <div className="space-y-8">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <FavoriteSectionSkeleton key={index} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {sections.map((section) => (
+        <FavoriteSection
+          key={section.title}
+          title={section.title}
+          items={section.items}
+          openModal={section.openModal}
+          type={section.type}
+          isEditing={isEditing}
+          handleDelete={section.handleDelete}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default FavoriteSections;

--- a/src/features/profile/ProfileHeader.tsx
+++ b/src/features/profile/ProfileHeader.tsx
@@ -1,0 +1,41 @@
+import Image from "next/image";
+import ProfileHeaderSkeleton from "./ProfileHeaderSkeleton";
+
+interface ProfileHeaderProps {
+  profileImageUrl: string | null | undefined;
+  viewedUserName: string | undefined;
+  isLoading: boolean;
+}
+
+const ProfileHeader = ({
+  profileImageUrl,
+  viewedUserName,
+  isLoading,
+}: ProfileHeaderProps) => {
+  if (isLoading) {
+    return <ProfileHeaderSkeleton />;
+  }
+
+  return (
+    <div className="flex flex-col gap-4 text-center mb-4">
+      {profileImageUrl ? (
+        <Image
+          className="rounded-full mx-auto"
+          src={profileImageUrl}
+          alt={`${viewedUserName}'s Profile Image`}
+          width={100}
+          height={100}
+          priority
+        />
+      ) : (
+        <div className="w-24 h-24 mx-auto bg-gray-500 rounded-full"></div>
+      )}
+
+      {viewedUserName && (
+        <h1 className="text-3xl font-bold">{viewedUserName}</h1>
+      )}
+    </div>
+  );
+};
+
+export default ProfileHeader;

--- a/src/features/profile/ProfileHeaderSkeleton.tsx
+++ b/src/features/profile/ProfileHeaderSkeleton.tsx
@@ -1,0 +1,12 @@
+const ProfileHeaderSkeleton = () => {
+  return (
+    <div className="animate-pulse">
+      <div className="flex flex-col gap-4 text-center mb-8">
+        <div className="w-24 h-24 bg-gray-500 rounded-full mx-auto"></div>
+        <div className="h-6 bg-gray-500 rounded mt-2 w-1/2 mx-auto"></div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileHeaderSkeleton;

--- a/src/features/ranking/RankingCategoryTabs.tsx
+++ b/src/features/ranking/RankingCategoryTabs.tsx
@@ -43,7 +43,7 @@ const RankingCategoryTabs = ({
           className={`text-xs md:text-lg px-0 md:px-4 py-1 md:py-2 duration-200 
             ${
               category === tab.key
-                ? "text-persianBlue font-bold shadow-lg"
+                ? "text-neonBlue font-bold shadow-lg"
                 : " text-gray-300  hover:text-neonBlue"
             }
           `}

--- a/src/hooks/useGlobalLoading.ts
+++ b/src/hooks/useGlobalLoading.ts
@@ -1,0 +1,20 @@
+import { useIsFetching, useIsMutating } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+const useGlobalLoading = () => {
+  const isFetching = useIsFetching();
+  const isMutating = useIsMutating();
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (isFetching > 0 || isMutating > 0) {
+      setIsLoading(true);
+    } else {
+      setIsLoading(false);
+    }
+  }, [isFetching, isMutating]);
+
+  return isLoading;
+};
+
+export default useGlobalLoading;

--- a/src/hooks/useProfileActions.ts
+++ b/src/hooks/useProfileActions.ts
@@ -1,0 +1,70 @@
+import { addFavorite, deleteFavorite } from "@/libs/utils/profileActions";
+import { SectionToItemType, UserFavorites } from "@/types/favorite";
+import { useState } from "react";
+
+interface UseProfileActionsProps {
+  editedFavorites: UserFavorites | null;
+  setEditedFavorites: React.Dispatch<
+    React.SetStateAction<UserFavorites | null>
+  >;
+}
+
+const useProfileActions = ({
+  editedFavorites,
+  setEditedFavorites,
+}: UseProfileActionsProps) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalType, setModalType] = useState<"artist" | "track" | undefined>(
+    undefined,
+  );
+  const [activeSection, setActiveSection] = useState<
+    keyof UserFavorites | undefined
+  >(undefined);
+
+  const openModal = (
+    type: "artist" | "track",
+    section: keyof UserFavorites,
+  ) => {
+    setModalType(type);
+    setActiveSection(section);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setModalType(undefined);
+    setActiveSection(undefined);
+  };
+
+  const handleDelete = <S extends keyof UserFavorites>(
+    section: S,
+    id: string,
+  ) => {
+    if (!editedFavorites) return;
+
+    const updatedFavorites = deleteFavorite(section, id, editedFavorites);
+    setEditedFavorites(updatedFavorites);
+  };
+
+  const handleAddItem = <S extends keyof UserFavorites>(
+    section: S,
+    item: SectionToItemType<S>,
+  ) => {
+    if (!editedFavorites) return;
+
+    const updatedFavorites = addFavorite(section, item, editedFavorites);
+    setEditedFavorites(updatedFavorites);
+  };
+
+  return {
+    isModalOpen,
+    modalType,
+    activeSection,
+    openModal,
+    closeModal,
+    handleDelete,
+    handleAddItem,
+  };
+};
+
+export default useProfileActions;

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,0 +1,73 @@
+import { fetchUserData, fetchUserFavorites } from "@/libs/utils/api";
+import { UserFavorites } from "@/types/favorite";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+
+interface UserData {
+  name: string;
+  profileImage: string | null;
+}
+
+const useUserProfile = (userId: number) => {
+  const queryClient = useQueryClient();
+
+  const {
+    data: userFavorites,
+    error: userFavoritesError,
+    isLoading: isFavoritesLoading,
+  } = useQuery<UserFavorites, Error>({
+    queryKey: ["userFavorites", userId],
+    queryFn: () => fetchUserFavorites(userId),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const {
+    data: userData,
+    error: userDataError,
+    isLoading: isUserDataLoading,
+  } = useQuery<UserData, Error>({
+    queryKey: ["userData", userId],
+    queryFn: () => fetchUserData(userId),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const mutation = useMutation<UserFavorites, Error, UserFavorites, unknown>({
+    mutationFn: async (newFavorites: UserFavorites) => {
+      const response = await axios.patch<UserFavorites>("/api/user-favorites", {
+        userId,
+        ...newFavorites,
+      });
+      return response.data;
+    },
+    onMutate: async (newFavorites) => {
+      await queryClient.cancelQueries({ queryKey: ["userFavorites", userId] });
+
+      const previousFavorites = queryClient.getQueryData<UserFavorites>([
+        "userFavorites",
+        userId,
+      ]);
+
+      queryClient.setQueryData(["userFavorites", userId], newFavorites);
+
+      return { previousFavorites };
+    },
+    onError: (error: unknown) => {
+      console.error("Error saving favorites:", error);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["userFavorites", userId] });
+    },
+  });
+
+  return {
+    userFavorites,
+    userFavoritesError,
+    isFavoritesLoading,
+    userData,
+    userDataError,
+    isUserDataLoading,
+    saveFavorites: mutation.mutate,
+  };
+};
+
+export default useUserProfile;

--- a/src/libs/utils/api.ts
+++ b/src/libs/utils/api.ts
@@ -1,0 +1,29 @@
+import { UserFavorites } from "@/types/favorite";
+import axios from "axios";
+
+export const fetchUserFavorites = async (
+  userId: number,
+): Promise<UserFavorites> => {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const response = await axios.get(
+    `${baseUrl}/api/user-favorites?userId=${userId}`,
+  );
+  const { allTimeArtists, allTimeTracks, currentArtists, currentTracks } =
+    response.data;
+
+  return {
+    allTimeArtists: allTimeArtists ?? [],
+    allTimeTracks: allTimeTracks ?? [],
+    currentArtists: currentArtists ?? [],
+    currentTracks: currentTracks ?? [],
+  };
+};
+
+export const fetchUserData = async (
+  userId: number,
+): Promise<{ name: string; profileImage: string | null }> => {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const response = await axios.get(`${baseUrl}/api/users?userId=${userId}`);
+  const { name, profileImage } = response.data;
+  return { name, profileImage };
+};

--- a/src/libs/utils/profileActions.ts
+++ b/src/libs/utils/profileActions.ts
@@ -1,0 +1,42 @@
+import {
+  isArtistSection,
+  isTrackSection,
+  SectionToItemType,
+  UserFavorites,
+} from "@/types/favorite";
+
+export const deleteFavorite = <S extends keyof UserFavorites>(
+  section: S,
+  id: string,
+  favorites: UserFavorites,
+): UserFavorites => {
+  const updatedFavorites: UserFavorites = { ...favorites };
+
+  if (isArtistSection(section)) {
+    updatedFavorites[section] = (updatedFavorites[section] as any[]).filter(
+      (item: any) => item.artistId !== id,
+    );
+  } else if (isTrackSection(section)) {
+    updatedFavorites[section] = (updatedFavorites[section] as any[]).filter(
+      (item: any) => item.trackId !== id,
+    );
+  }
+
+  return updatedFavorites;
+};
+
+export const addFavorite = <S extends keyof UserFavorites>(
+  section: S,
+  item: SectionToItemType<S>,
+  favorites: UserFavorites,
+): UserFavorites => {
+  const updatedFavorites: UserFavorites = { ...favorites };
+
+  if (isArtistSection(section)) {
+    updatedFavorites[section] = [...(updatedFavorites[section] as any[]), item];
+  } else if (isTrackSection(section)) {
+    updatedFavorites[section] = [...(updatedFavorites[section] as any[]), item];
+  }
+
+  return updatedFavorites;
+};

--- a/src/pages/artist/[artistId].tsx
+++ b/src/pages/artist/[artistId].tsx
@@ -43,12 +43,12 @@ const ArtistPage = ({ artistId }: ArtistPageProps) => {
   return (
     <div className="max-w-4xl mx-auto p-6 mt-8 bg-zinc-800 rounded-lg shadow-md">
       <NextSeo
-        title={`Track List Now - ${data.artist.name}`}
+        title={`${data.artist.name} - Track List Now`}
         description={`Basic Information, Top tracks, Related artists of ${data.artist.name}`}
         openGraph={{
           type: "music.artist",
           url: `https://www.tracklistnow.com/artist/${artistId}`,
-          title: `Track List Now - ${data.artist.name}`,
+          title: `${data.artist.name} - Track List Now`,
           description: `Discover more about ${data.artist.name} on Track List Now!`,
           images: [
             {

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,138 +1,63 @@
 import ErrorComponent from "@/features/common/ErrorComponent";
-import FavoriteSection from "@/features/profile/FavoriteSection";
+import EditControls from "@/features/profile/EditControls";
+import FavoriteSections from "@/features/profile/FavoriteSections";
+import ProfileHeader from "@/features/profile/ProfileHeader";
 import SearchModal from "@/features/profile/SearchModal";
+import useProfileActions from "@/hooks/useProfileActions";
+import useUserProfile from "@/hooks/useUserProfile";
+import { fetchUserData, fetchUserFavorites } from "@/libs/utils/api";
 import {
-  isArtistSection,
-  isTrackSection,
-  SectionToItemType,
   UserFavoriteArtist,
   UserFavorites,
   UserFavoriteTrack,
 } from "@/types/favorite";
-import {
-  dehydrate,
-  QueryClient,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
-import axios from "axios";
-import { saveAs } from "file-saver";
-import * as htmlToImage from "html-to-image";
+import { dehydrate, QueryClient } from "@tanstack/react-query";
 import { GetServerSideProps } from "next";
 import { getSession, useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { NextSeo } from "next-seo";
-import Image from "next/image";
-import { useCallback, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 interface ProfilePageProps {
   userId: number;
 }
 
-const fetchUserFavorites = async (userId: number): Promise<UserFavorites> => {
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
-  const response = await axios.get(
-    `${baseUrl}/api/user-favorites?userId=${userId}`,
-  );
-  const { allTimeArtists, allTimeTracks, currentArtists, currentTracks } =
-    response.data;
-
-  return {
-    allTimeArtists: allTimeArtists ?? [],
-    allTimeTracks: allTimeTracks ?? [],
-    currentArtists: currentArtists ?? [],
-    currentTracks: currentTracks ?? [],
-  };
-};
-
-const fetchUserData = async (
-  userId: number,
-): Promise<{ name: string; profileImage: string | null }> => {
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
-  const response = await axios.get(`${baseUrl}/api/users?userId=${userId}`);
-  const { name, profileImage } = response.data;
-  return { name, profileImage };
-};
-
 const ProfilePage = ({ userId }: ProfilePageProps) => {
   const { t } = useTranslation(["common", "profile"]);
   const { data: session } = useSession();
-  const queryClient = useQueryClient();
-  const isOwnProfile = userId === Number(session?.user.id);
 
-  const { data: userFavorites, error: userFavoritesError } = useQuery<
-    UserFavorites,
-    Error
-  >({
-    queryKey: ["userFavorites", userId],
-    queryFn: () => fetchUserFavorites(userId),
-    staleTime: 5 * 60 * 1000,
-  });
-
-  const { data: userData, error: userDataError } = useQuery<
-    { name: string; profileImage: string | null },
-    Error
-  >({
-    queryKey: ["userData", userId],
-    queryFn: () => fetchUserData(userId),
-    staleTime: 5 * 60 * 1000,
-  });
+  const {
+    userFavorites,
+    userFavoritesError,
+    isFavoritesLoading,
+    userData,
+    userDataError,
+    isUserDataLoading,
+    saveFavorites,
+  } = useUserProfile(userId);
 
   const [isEditing, setIsEditing] = useState(false);
   const [editedFavorites, setEditedFavorites] = useState<UserFavorites | null>(
     null,
   );
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [modalType, setModalType] = useState<"artist" | "track" | undefined>(
-    undefined,
-  );
-  const [activeSection, setActiveSection] = useState<
-    keyof UserFavorites | undefined
-  >(undefined);
+
+  const {
+    isModalOpen,
+    modalType,
+    activeSection,
+    openModal,
+    closeModal,
+    handleDelete,
+    handleAddItem,
+  } = useProfileActions({
+    editedFavorites,
+    setEditedFavorites,
+  });
 
   const pageRef = useRef<HTMLDivElement>(null);
 
-  const mutation = useMutation<UserFavorites, Error, UserFavorites, unknown>({
-    mutationFn: async (newFavorites: UserFavorites) => {
-      const response = await axios.patch<UserFavorites>("/api/user-favorites", {
-        userId: session?.user?.id,
-        allTimeArtists: newFavorites.allTimeArtists,
-        allTimeTracks: newFavorites.allTimeTracks,
-        currentArtists: newFavorites.currentArtists,
-        currentTracks: newFavorites.currentTracks,
-      });
-      return response.data;
-    },
-    onSuccess: () => {
-      // 관련 쿼리 무효화 및 상태 업데이트
-      queryClient.invalidateQueries({ queryKey: ["userFavorites", userId] });
-      setIsEditing(false);
-      setEditedFavorites(null);
-    },
-    onError: (error: unknown) => {
-      // TODO: 에러 처리
-      JSON.stringify(error);
-    },
-  });
-
-  const openModal = (
-    type: "artist" | "track",
-    section: keyof UserFavorites,
-  ) => {
-    setModalType(type);
-    setActiveSection(section);
-    setIsModalOpen(true);
-  };
-
-  const closeModal = () => {
-    setIsModalOpen(false);
-    setModalType(undefined);
-    setActiveSection(undefined);
-  };
-
-  const toggleEditing = () => {
+  const handleToggleEditing = () => {
     if (!isEditing) {
       // 편집 모드로 전환될 때, 현재 favorites를 로컬 상태로 복사
       setEditedFavorites(userFavorites ? { ...userFavorites } : null);
@@ -143,95 +68,25 @@ const ProfilePage = ({ userId }: ProfilePageProps) => {
     setIsEditing((prev) => !prev);
   };
 
-  const handleSaveChanges = () => {
-    if (!isOwnProfile || !session?.user?.id || !editedFavorites) {
-      return;
-    }
-    mutation.mutate(editedFavorites);
-  };
-
-  const handleSaveAsImage = useCallback(() => {
-    if (pageRef.current === null) return;
-
-    const filter = (node: HTMLElement) => {
-      const exclusionClasses = ["not-contain"];
-      return !exclusionClasses.some((classname) =>
-        node.classList?.contains(classname),
-      );
-    };
-
-    htmlToImage
-      .toJpeg(pageRef.current, {
-        cacheBust: true,
-        includeQueryParams: true,
-        filter,
-      })
-      .then((dataUrl) => {
-        const now = new Date();
-        const formattedDate = `${now.getFullYear().toString().slice(2)}${String(
-          now.getMonth() + 1,
-        ).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}${String(
-          now.getHours(),
-        ).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}`;
-        const fileName = `${isOwnProfile && session?.user?.name}-${formattedDate}.jpeg`;
-        saveAs(dataUrl, fileName);
-      })
-      .catch((error: unknown) => {
-        // TODO: 에러 처리
-        JSON.stringify(error);
-      });
-  }, [pageRef, session, isOwnProfile]);
-
-  const handleDelete = <S extends keyof UserFavorites>(
-    section: S,
-    id: string,
-  ) => {
-    if (!editedFavorites) return;
-
-    const updatedFavorites: UserFavorites = { ...editedFavorites };
-
-    if (isArtistSection(section)) {
-      updatedFavorites[section] = (
-        updatedFavorites[section] as UserFavoriteArtist[]
-      ).filter((item) => item.artistId !== id);
-    } else if (isTrackSection(section)) {
-      updatedFavorites[section] = (
-        updatedFavorites[section] as UserFavoriteTrack[]
-      ).filter((item) => item.trackId !== id);
-    }
-
-    setEditedFavorites(updatedFavorites);
-  };
-
-  const handleAddItem = <S extends keyof UserFavorites>(
-    section: S,
-    item: SectionToItemType<S>,
-  ) => {
-    if (!editedFavorites) return;
-
-    const updatedFavorites: UserFavorites = { ...editedFavorites };
-
-    if (isArtistSection(section)) {
-      updatedFavorites[section] = [
-        ...(updatedFavorites[section] as UserFavoriteArtist[]),
-        item as UserFavoriteArtist,
-      ];
-    } else if (isTrackSection(section)) {
-      updatedFavorites[section] = [
-        ...(updatedFavorites[section] as UserFavoriteTrack[]),
-        item as UserFavoriteTrack,
-      ];
-    }
-
-    setEditedFavorites(updatedFavorites);
-  };
-
-  const viewedUserName = userData?.name || "Unknown User";
-  const profileImageUrl = userData?.profileImage || null;
-
   // 편집 모드일 때는 editedFavorites를, 아닐 때는 userFavorites를 사용
   const displayFavorites =
     isEditing && editedFavorites ? editedFavorites : userFavorites;
+
+  const handleSaveChanges = async () => {
+    if (!session?.user?.id || !editedFavorites) {
+      return;
+    }
+    try {
+      await saveFavorites(editedFavorites);
+      setIsEditing(false);
+      setEditedFavorites(null);
+    } catch (error: unknown) {
+      alert("저장에 실패했습니다. 다시 시도해주세요.");
+    }
+  };
+
+  const viewedUserName = userData?.name;
+  const profileImageUrl = userData?.profileImage;
 
   if (userFavoritesError || userDataError) {
     return (
@@ -241,22 +96,61 @@ const ProfilePage = ({ userId }: ProfilePageProps) => {
     );
   }
 
+  const isLoading = isFavoritesLoading || isUserDataLoading;
+
+  const sections: {
+    title: string;
+    items: UserFavoriteArtist[] | UserFavoriteTrack[];
+    type: "artist" | "track";
+    openModal: () => void;
+    handleDelete: (id: string) => void;
+  }[] = [
+    {
+      title: t("all_time_favorite_artists"),
+      items: displayFavorites?.allTimeArtists || [],
+      type: "artist",
+      openModal: () => openModal("artist", "allTimeArtists"),
+      handleDelete: (id: string) => handleDelete("allTimeArtists", id),
+    },
+    {
+      title: t("all_time_favorite_tracks"),
+      items: displayFavorites?.allTimeTracks || [],
+      type: "track",
+      openModal: () => openModal("track", "allTimeTracks"),
+      handleDelete: (id: string) => handleDelete("allTimeTracks", id),
+    },
+    {
+      title: t("current_favorite_artists"),
+      items: displayFavorites?.currentArtists || [],
+      type: "artist",
+      openModal: () => openModal("artist", "currentArtists"),
+      handleDelete: (id: string) => handleDelete("currentArtists", id),
+    },
+    {
+      title: t("current_favorite_tracks"),
+      items: displayFavorites?.currentTracks || [],
+      type: "track",
+      openModal: () => openModal("track", "currentTracks"),
+      handleDelete: (id: string) => handleDelete("currentTracks", id),
+    },
+  ];
+
   return (
     <div className="max-w-3xl mx-auto text-white">
       <NextSeo
-        title={`Track List Now - ${viewedUserName}`}
-        description={`${viewedUserName}'s favorite artists and tracks on Track List Now`}
+        title={`${profileImageUrl} - Track List Now`}
+        description={`${profileImageUrl}'s favorite artists and tracks on Track List Now`}
         openGraph={{
           type: "profile",
           url: `https://www.tracklistnow.com/profile/${userId}`,
-          title: `Track List Now - ${viewedUserName}`,
-          description: `${viewedUserName}'s favorite artists and tracks`,
+          title: `${profileImageUrl} - Track List Now`,
+          description: `${profileImageUrl}'s favorite artists and tracks`,
           images: [
             {
               url: profileImageUrl || "/default-profile-image.jpg",
               width: 800,
               height: 800,
-              alt: `${viewedUserName}'s Profile Image`,
+              alt: `${profileImageUrl}'s Profile Image`,
             },
           ],
         }}
@@ -267,86 +161,28 @@ const ProfilePage = ({ userId }: ProfilePageProps) => {
         }}
       />
       <div ref={pageRef} className="p-6">
-        {isOwnProfile ? (
-          <div className="flex flex-col gap-4 text-center mb-4">
-            {profileImageUrl ? (
-              <Image
-                className="rounded-full mx-auto"
-                src={profileImageUrl}
-                alt={`${viewedUserName}'s Profile Image`}
-                width={100}
-                height={100}
-              />
-            ) : (
-              <div className="w-24 h-24">{null}</div>
-            )}
+        <ProfileHeader
+          profileImageUrl={profileImageUrl}
+          viewedUserName={viewedUserName}
+          isLoading={isLoading}
+        />
 
-            <h1 className="text-3xl font-bold">{viewedUserName}</h1>
-          </div>
-        ) : (
-          <div className="w-[150px] h-[150px]">{null}</div>
-        )}
+        <EditControls
+          label={
+            isEditing
+              ? t("save", { ns: "profile" })
+              : t("edit", { ns: "profile" })
+          }
+          isEditing={isEditing}
+          toggleEditing={handleToggleEditing}
+          handleSaveChanges={handleSaveChanges}
+        />
 
-        {isOwnProfile && (
-          <div className="flex justify-end mb-6">
-            <button
-              onClick={isEditing ? handleSaveChanges : toggleEditing}
-              className="not-contain bg-persianBlue text-white px-4 py-2 rounded-lg"
-              type="button"
-            >
-              {isEditing
-                ? t("save", { ns: "profile" })
-                : t("edit", { ns: "profile" })}
-            </button>
-          </div>
-        )}
-
-        <div>
-          <FavoriteSection
-            title={t("all_time_favorite_artists")}
-            items={displayFavorites?.allTimeArtists || []}
-            openModal={() => openModal("artist", "allTimeArtists")}
-            type="artist"
-            isEditing={isOwnProfile && isEditing}
-            handleDelete={(id) => handleDelete("allTimeArtists", id)}
-          />
-          <FavoriteSection
-            title={t("all_time_favorite_tracks")}
-            items={displayFavorites?.allTimeTracks || []}
-            openModal={() => openModal("track", "allTimeTracks")}
-            type="track"
-            isEditing={isOwnProfile && isEditing}
-            handleDelete={(id) => handleDelete("allTimeTracks", id)}
-          />
-          <FavoriteSection
-            title={t("current_favorite_artists")}
-            items={displayFavorites?.currentArtists || []}
-            openModal={() => openModal("artist", "currentArtists")}
-            type="artist"
-            isEditing={isOwnProfile && isEditing}
-            handleDelete={(id) => handleDelete("currentArtists", id)}
-          />
-          <FavoriteSection
-            title={t("current_favorite_tracks")}
-            items={displayFavorites?.currentTracks || []}
-            openModal={() => openModal("track", "currentTracks")}
-            type="track"
-            isEditing={isOwnProfile && isEditing}
-            handleDelete={(id) => handleDelete("currentTracks", id)}
-          />
-        </div>
-
-        {!isEditing && (
-          <div className="flex justify-center mt-6">
-            <button
-              onClick={handleSaveAsImage}
-              className="not-contain bg-persianBlue text-white px-4 py-2 rounded-lg"
-              type="button"
-            >
-              {t("to_image", { ns: "profile" })}
-            </button>
-          </div>
-        )}
+        <FavoriteSections
+          sections={sections}
+          isEditing={isEditing}
+          isLoading={isLoading}
+        />
 
         {isModalOpen && modalType && activeSection && (
           <SearchModal

--- a/src/pages/ranking/[category].tsx
+++ b/src/pages/ranking/[category].tsx
@@ -1,6 +1,7 @@
 import ErrorComponent from "@/features/common/ErrorComponent";
 import TItem from "@/features/common/TItem";
 import RankingCategoryTabs from "@/features/ranking/RankingCategoryTabs";
+import useGlobalLoading from "@/hooks/useGlobalLoading";
 import { convertToCategory } from "@/libs/utils/categoryMapper";
 import {
   isArtistWithRanking,
@@ -31,8 +32,9 @@ const fetchRankingData = async (category: string): Promise<TItemData[]> => {
 const RankingPage = ({ category }: RankingPageProps) => {
   const { t } = useTranslation("common");
   const router = useRouter();
+  const isLoading = useGlobalLoading();
 
-  const { data: rankingData, error } = useQuery<TItemData[], Error>({
+  const { data: rankingData = [], error } = useQuery<TItemData[], Error>({
     queryKey: ["ranking", category],
     queryFn: () => fetchRankingData(category),
     staleTime: 5 * 60 * 1000,
@@ -61,10 +63,6 @@ const RankingPage = ({ category }: RankingPageProps) => {
     return <ErrorComponent message={`Error loading data: ${error.message}`} />;
   }
 
-  if (!rankingData || rankingData.length === 0) {
-    return <div className="text-center text-gray-400">{t("no_data")}</div>;
-  }
-
   let sectionType: "artist" | "track" = "artist";
   let sectionData: TItemData[] = [];
 
@@ -91,12 +89,12 @@ const RankingPage = ({ category }: RankingPageProps) => {
   return (
     <div className="max-w-5xl mx-auto p-6">
       <NextSeo
-        title={`Track List Now - ${pageTitle}`}
+        title={`${pageTitle} - Track List Now`}
         description={pageDescription}
         openGraph={{
           type: "website",
           url: `https://www.tracklistnow.com/ranking/${category.toLowerCase()}`,
-          title: `Track List Now - ${pageTitle}`,
+          title: `${pageTitle} - Track List Now`,
           description: pageDescription,
           images: [
             {
@@ -120,7 +118,7 @@ const RankingPage = ({ category }: RankingPageProps) => {
       />
 
       <h1 className="text-3xl font-bold text-white mb-6">{t(title)}</h1>
-      {sectionData.length === 0 ? (
+      {!isLoading && sectionData.length === 0 ? (
         <p className="text-gray-400 text-center mt-4">{t("no_data")}</p>
       ) : (
         <ul className="space-y-4">

--- a/src/pages/track/[trackId].tsx
+++ b/src/pages/track/[trackId].tsx
@@ -1,5 +1,4 @@
 import ErrorComponent from "@/features/common/ErrorComponent";
-import LoadingBar from "@/features/common/LoadingBar";
 import TrackSection from "@/features/track/TrackSection";
 import { TrackDetail } from "@/types/track";
 import { dehydrate, QueryClient, useQuery } from "@tanstack/react-query";
@@ -22,19 +21,11 @@ const fetchTrackDetail = async (trackId: string): Promise<TrackDetail> => {
 const TrackPage = ({ trackId }: TrackPageProps) => {
   const { t } = useTranslation(["common", "track"]);
 
-  const {
-    data: track,
-    error,
-    isLoading,
-  } = useQuery<TrackDetail, Error>({
+  const { data: track, error } = useQuery<TrackDetail, Error>({
     queryKey: ["track", trackId],
     queryFn: () => fetchTrackDetail(trackId),
     staleTime: 5 * 60 * 1000,
   });
-
-  if (isLoading) {
-    return <LoadingBar />;
-  }
 
   if (error) {
     return <ErrorComponent message={`Error loading data: ${error.message}`} />;
@@ -50,12 +41,12 @@ const TrackPage = ({ trackId }: TrackPageProps) => {
   return (
     <div className="max-w-4xl mx-auto p-6 mt-8 bg-zinc-800 rounded-lg shadow-md">
       <NextSeo
-        title={`Track List Now - ${trackTitle}`}
+        title={`${trackTitle} - Track List Now`}
         description={`Listen to ${trackTitle} by ${artistNames}. Find information about the album, release date, and duration.`}
         openGraph={{
           type: "music.song",
           url: `https://www.tracklistnow.com/track/${trackId}`,
-          title: `Track List Now - ${trackTitle}`,
+          title: `${trackTitle} - Track List Now`,
           description: `Listen to ${trackTitle} by ${artistNames}. Find information about the album, release date, and duration.`,
           images: [
             {


### PR DESCRIPTION
1. [Feat: 프로필 페이지 데이터 페칭 커스텀훅 추가, 스켈레톤UI 추가](https://github.com/jihohub/track-list-now/commit/2d7c005795c4fa9b5bb2fecc5e98cb801d9a31c3)
2. [Feat: 랭킹 페이지에 탭을 추가하여 랭킹 페이지 내에서 랭킹의 카테고리를 변경할 수 있도록 수정](https://github.com/jihohub/track-list-now/commit/d00b40bdd10befb860ffbf081a85b277bab1c9ab)
3. [Feat: GlobalLoadingBar 컴포넌트에서 로딩 여부를 판단할 커스텀훅 추가](https://github.com/jihohub/track-list-now/commit/9c54f63b7dc3a06cf65dbbd548c47b17de5ab299)
4. [Design: 데스크탑용 푸터, 모바일에서 display:hidden 추가](https://github.com/jihohub/track-list-now/commit/e0275bec9b1a083f484e8db8eaf677dd1c8f8508)
5. [Chore: 메타데이터 Track List Now 문구를 아티스트명이나 트랙명의 뒤로 오도록 수정](https://github.com/jihohub/track-list-now/commit/97e8062524eb66fb5199264b99ed49da898fd19d)
6. [Chore: next-auth 버전 변경](https://github.com/jihohub/track-list-now/commit/89a878dce5907da471cca3dab8d5dfd4c349b5bb)