### PR TITLE
Fix: SearchResultList 컴포넌트에서 페이지별로 제대로 된 i18n json을 가져오도록 수정

### DIFF
--- a/src/features/liked/components/LikedSection.tsx
+++ b/src/features/liked/components/LikedSection.tsx
@@ -84,6 +84,7 @@ const LikedSection = () => {
               listType="artist"
               fetchMore={() => {}}
               hasMore={false}
+              page="liked"
             />
           )}
           {tracks.length > 0 && (
@@ -92,6 +93,7 @@ const LikedSection = () => {
               listType="track"
               fetchMore={() => {}}
               hasMore={false}
+              page="liked"
             />
           )}
           {albums.length > 0 && (
@@ -100,6 +102,7 @@ const LikedSection = () => {
               listType="album"
               fetchMore={() => {}}
               hasMore={false}
+              page="liked"
             />
           )}
         </>
@@ -123,6 +126,7 @@ const LikedSection = () => {
           }
           fetchMore={fetchNextPage}
           hasMore={hasNextPage || false}
+          page="liked"
         />
       )}
 

--- a/src/features/search/components/SearchResultList.tsx
+++ b/src/features/search/components/SearchResultList.tsx
@@ -9,6 +9,7 @@ interface SearchResultListProps {
   listType: "artist" | "track" | "album";
   fetchMore: () => void;
   hasMore: boolean;
+  page: "search" | "liked";
 }
 
 const SearchResultList = ({
@@ -16,13 +17,14 @@ const SearchResultList = ({
   listType,
   fetchMore,
   hasMore,
+  page,
 }: SearchResultListProps) => {
-  const { t } = useTranslation(["common", "search"]);
+  const { t } = useTranslation(["common", page]);
 
   return (
     <div className="mt-6">
       <h3 className="text-lg font-semibold text-white mb-2">
-        {t(listType, { ns: "search" })}
+        {t(listType, { ns: page })}
       </h3>
       <InfiniteScroll
         dataLength={searchResults.length}

--- a/src/features/search/components/SearchSection.tsx
+++ b/src/features/search/components/SearchSection.tsx
@@ -121,6 +121,7 @@ const SearchSection = () => {
               listType="artist"
               fetchMore={() => {}}
               hasMore={false}
+              page="search"
             />
           )}
           {tracks.length > 0 && (
@@ -129,6 +130,7 @@ const SearchSection = () => {
               listType="track"
               fetchMore={() => {}}
               hasMore={false}
+              page="search"
             />
           )}
           {albums.length > 0 && (
@@ -137,6 +139,7 @@ const SearchSection = () => {
               listType="album"
               fetchMore={() => {}}
               hasMore={false}
+              page="search"
             />
           )}
         </>
@@ -160,6 +163,7 @@ const SearchSection = () => {
           }
           fetchMore={fetchNextPage}
           hasMore={hasNextPage || false}
+          page="search"
         />
       )}
 


### PR DESCRIPTION
1. [Fix: SearchResultList 컴포넌트에서 페이지별로 제대로 된 i18n json을 가져오도록 수정](https://github.com/jihohub/track-list-now/commit/b5aae19a6b3900e85841498a8271c85ccdfbe889)