### PR TITLE
Fix: cloudflare로 DNS 호스팅 옮긴 이후 발생하는 스포티파이 API 403 에러에 대한 설정 추가

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,41 @@ const nextConfig = {
   experimental: {
     instrumentationHook: true,
   },
+  // CORS 및 캐시 헤더 설정 추가
+  async headers() {
+    return [
+      {
+        source: "/api/:path*",
+        headers: [
+          {
+            key: "Access-Control-Allow-Origin",
+            value: "https://tracklistnow.com",
+          },
+          {
+            key: "Access-Control-Allow-Methods",
+            value: "GET,OPTIONS,PATCH,DELETE,POST,PUT",
+          },
+          {
+            key: "Access-Control-Allow-Headers",
+            value:
+              "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization",
+          },
+          {
+            key: "Cache-Control",
+            value: "no-store, no-cache, must-revalidate, proxy-revalidate",
+          },
+          {
+            key: "Pragma",
+            value: "no-cache",
+          },
+          {
+            key: "Expires",
+            value: "0",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 const sentryWebpackPluginOptions = {


### PR DESCRIPTION
1. [Fix: cloudflare로 DNS 호스팅 옮긴 이후 발생하는 스포티파이 API 403 에러에 대한 설정 추가](https://github.com/jihohub/track-list-now/commit/d2c3d14435c0db195d31c8aa403bfe03051e4c67)