### PR TITLE
Fix: cloudflare로 DNS 호스팅 옮긴 이후 발생하는 스포티파이 API 403 에러에 대한 설정 추가

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,41 @@ const nextConfig = {
   experimental: {
     instrumentationHook: true,
   },
+  // CORS 및 캐시 헤더 설정 추가
+  async headers() {
+    return [
+      {
+        source: "/api/:path*",
+        headers: [
+          {
+            key: "Access-Control-Allow-Origin",
+            value: "https://tracklistnow.com",
+          },
+          {
+            key: "Access-Control-Allow-Methods",
+            value: "GET,OPTIONS,PATCH,DELETE,POST,PUT",
+          },
+          {
+            key: "Access-Control-Allow-Headers",
+            value:
+              "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization",
+          },
+          {
+            key: "Cache-Control",
+            value: "no-store, no-cache, must-revalidate, proxy-revalidate",
+          },
+          {
+            key: "Pragma",
+            value: "no-cache",
+          },
+          {
+            key: "Expires",
+            value: "0",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 const sentryWebpackPluginOptions = {

--- a/src/hooks/useScrollRestoration.ts
+++ b/src/hooks/useScrollRestoration.ts
@@ -1,4 +1,3 @@
-// hooks/useScrollRestoration.ts
 import { useRouter } from "next/router";
 import { useEffect, useRef } from "react";
 
@@ -15,15 +14,15 @@ const useScrollRestoration = () => {
     });
 
     // 페이지 이동 시작 시 현재 스크롤 위치 저장
-    const saveScrollPosition = (url: string) => {
+    const saveScrollPosition = () => {
       scrollPositions.current[router.asPath] = window.scrollY;
     };
 
     // 페이지 이동 완료 후 스크롤 위치 복원 또는 최상단 이동
-    const restoreScrollPosition = (url: string) => {
+    const restoreScrollPosition = (nextPath: string) => {
       if (isBack.current) {
         // 뒤로가기의 경우 저장된 위치로 스크롤
-        const savedPosition = scrollPositions.current[url];
+        const savedPosition = scrollPositions.current[nextPath];
         if (savedPosition !== undefined) {
           setTimeout(() => {
             window.scrollTo(0, savedPosition);


### PR DESCRIPTION
1. [Fix: cloudflare로 DNS 호스팅 옮긴 이후 발생하는 스포티파이 API 403 에러에 대한 설정 추가](https://github.com/jihohub/track-list-now/commit/d2c3d14435c0db195d31c8aa403bfe03051e4c67)