### PR TITLE
Fix: album 페이지와 aritst 페이지에서 track을 미리듣기하다가 like 버튼을 누를 때 제대로 동작하지 않던…

### DIFF
--- a/prisma/migrations/20241109121714_remove_duration_ms_at_track_table/migration.sql
+++ b/prisma/migrations/20241109121714_remove_duration_ms_at_track_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `durationMs` on the `Track` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Track" DROP COLUMN "durationMs";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -141,7 +141,6 @@ model Track {
   artists           String
   popularity        Int
   previewUrl        String?
-  durationMs        Int
   createdAt         DateTime             @default(now())
   updatedAt         DateTime             @updatedAt
 

--- a/src/features/liked/components/LikedSEO.tsx
+++ b/src/features/liked/components/LikedSEO.tsx
@@ -1,0 +1,40 @@
+import { NextSeo } from "next-seo";
+
+interface LikedSEOProps {
+  userName?: string;
+  userProfileImage?: string | null;
+}
+
+const LikedSEO = ({ userName = "User", userProfileImage }: LikedSEOProps) => (
+  <NextSeo
+    title={`${userName}'s Liked Collection - Track List Now`}
+    description={`${userName}'s Liked Collection - Track List Now`}
+    openGraph={{
+      type: "music.playlist",
+      url: "https://www.tracklistnow.com/liked",
+      title: `${userName}'s Liked Collection - Track List Now`,
+      description: `${userName}'s Liked Collection - Track List Now`,
+      images: [
+        {
+          url: userProfileImage || "/default-liked-collection-image.jpg",
+          width: 800,
+          height: 800,
+          alt: `${userName}'s Liked Collection`,
+        },
+      ],
+    }}
+    twitter={{
+      handle: "@TrackListNow",
+      site: "@TrackListNow",
+      cardType: "summary_large_image",
+    }}
+    additionalMetaTags={[
+      {
+        name: "music:creator",
+        content: userName,
+      },
+    ]}
+  />
+);
+
+export default LikedSEO;

--- a/src/features/liked/mutations/useLikeMutation.ts
+++ b/src/features/liked/mutations/useLikeMutation.ts
@@ -10,7 +10,6 @@ interface LikeItemPayload {
   artists?: string;
   followers?: number;
   previewUrl?: string | null;
-  durationMs?: number;
   popularity?: number;
   releaseDate?: string;
 }
@@ -38,7 +37,6 @@ const useLikeMutation = () => {
         artists: payload.artists,
         followers: payload.followers,
         previewUrl: payload.previewUrl,
-        durationMs: payload.durationMs,
         popularity: payload.popularity,
         releaseDate: payload.releaseDate,
       }),

--- a/src/features/profile/components/FavoriteSections.tsx
+++ b/src/features/profile/components/FavoriteSections.tsx
@@ -1,14 +1,6 @@
 import FavoriteSection from "@/features/profile/components/FavoriteSection";
 import FavoriteSectionSkeleton from "@/features/profile/components/FavoriteSectionSkeleton";
-import { UserFavorites } from "@/types/favorite";
-
-interface SectionConfig {
-  title: string;
-  items: UserFavorites[keyof UserFavorites];
-  type: "artist" | "track";
-  openModal: () => void;
-  handleDelete: (id: string) => void;
-}
+import { SectionConfig } from "@/types/section";
 
 interface FavoriteSectionsProps {
   sections: SectionConfig[];
@@ -16,11 +8,11 @@ interface FavoriteSectionsProps {
   isLoading?: boolean;
 }
 
-const FavoriteSections: React.FC<FavoriteSectionsProps> = ({
+const FavoriteSections = ({
   sections,
   isEditing,
   isLoading = false,
-}) => {
+}: FavoriteSectionsProps) => {
   if (isLoading) {
     return (
       <div className="space-y-8">
@@ -37,12 +29,8 @@ const FavoriteSections: React.FC<FavoriteSectionsProps> = ({
       {sections.map((section) => (
         <FavoriteSection
           key={section.title}
-          title={section.title}
-          items={section.items}
-          openModal={section.openModal}
-          type={section.type}
+          {...section}
           isEditing={isEditing}
-          handleDelete={section.handleDelete}
         />
       ))}
     </div>

--- a/src/features/profile/components/ProfileHeader.tsx
+++ b/src/features/profile/components/ProfileHeader.tsx
@@ -1,15 +1,15 @@
+import ProfileHeaderSkeleton from "@/features/profile/components/ProfileHeaderSkeleton";
 import Image from "next/image";
-import ProfileHeaderSkeleton from "./ProfileHeaderSkeleton";
 
 interface ProfileHeaderProps {
-  profileImageUrl: string | null | undefined;
-  viewedUserName: string | undefined;
+  viewedUserName?: string;
+  profileImageUrl?: string | null;
   isLoading: boolean;
 }
 
 const ProfileHeader = ({
-  profileImageUrl,
   viewedUserName,
+  profileImageUrl,
   isLoading,
 }: ProfileHeaderProps) => {
   if (isLoading) {

--- a/src/features/profile/components/ProfileSEO.tsx
+++ b/src/features/profile/components/ProfileSEO.tsx
@@ -2,7 +2,7 @@ import { NextSeo } from "next-seo";
 
 interface ProfileSEOProps {
   viewedUserName?: string;
-  profileImageUrl?: string;
+  profileImageUrl?: string | null;
   userId: number;
 }
 

--- a/src/features/profile/components/ProfileSection.tsx
+++ b/src/features/profile/components/ProfileSection.tsx
@@ -2,7 +2,8 @@ import EditControls from "@/features/profile/components/EditControls";
 import FavoriteSections from "@/features/profile/components/FavoriteSections";
 import ProfileHeader from "@/features/profile/components/ProfileHeader";
 import SearchModal from "@/features/profile/components/SearchModal";
-import { UserFavorites } from "@/types/favorite";
+import { SectionToItemType, UserFavorites } from "@/types/favorite";
+import { SectionConfig } from "@/types/section";
 import { useTranslation } from "next-i18next";
 import { RefObject } from "react";
 
@@ -12,13 +13,7 @@ interface ProfileSectionProps {
   isLoading: boolean;
   isEditing: boolean;
   editedFavorites: UserFavorites | null;
-  sections: {
-    title: string;
-    items: any[];
-    type: "artist" | "track";
-    openModal: () => void;
-    handleDelete: (id: string) => void;
-  }[];
+  sections: SectionConfig[];
   pageRef: RefObject<HTMLDivElement>;
   isModalOpen: boolean;
   modalType?: "artist" | "track" | null;
@@ -26,7 +21,10 @@ interface ProfileSectionProps {
   handleToggleEditing: () => void;
   handleSaveChanges: () => Promise<void>;
   closeModal: () => void;
-  handleAddItem: (section: keyof UserFavorites, item: any) => void;
+  handleAddItem: <S extends keyof UserFavorites>(
+    section: S,
+    item: SectionToItemType<S>,
+  ) => void;
 }
 
 const ProfileSection = ({

--- a/src/features/profile/components/ProfileSection.tsx
+++ b/src/features/profile/components/ProfileSection.tsx
@@ -1,0 +1,92 @@
+import EditControls from "@/features/profile/components/EditControls";
+import FavoriteSections from "@/features/profile/components/FavoriteSections";
+import ProfileHeader from "@/features/profile/components/ProfileHeader";
+import SearchModal from "@/features/profile/components/SearchModal";
+import { UserFavorites } from "@/types/favorite";
+import { useTranslation } from "next-i18next";
+import { RefObject } from "react";
+
+interface ProfileSectionProps {
+  viewedUserName?: string;
+  profileImageUrl?: string | null;
+  isLoading: boolean;
+  isEditing: boolean;
+  editedFavorites: UserFavorites | null;
+  sections: {
+    title: string;
+    items: any[];
+    type: "artist" | "track";
+    openModal: () => void;
+    handleDelete: (id: string) => void;
+  }[];
+  pageRef: RefObject<HTMLDivElement>;
+  isModalOpen: boolean;
+  modalType?: "artist" | "track" | null;
+  activeSection?: string | null;
+  handleToggleEditing: () => void;
+  handleSaveChanges: () => Promise<void>;
+  closeModal: () => void;
+  handleAddItem: (section: keyof UserFavorites, item: any) => void;
+}
+
+const ProfileSection = ({
+  viewedUserName,
+  profileImageUrl,
+  isLoading,
+  isEditing,
+  editedFavorites,
+  sections,
+  pageRef,
+  isModalOpen,
+  modalType,
+  activeSection,
+  handleToggleEditing,
+  handleSaveChanges,
+  closeModal,
+  handleAddItem,
+}: ProfileSectionProps) => {
+  const { t } = useTranslation(["common", "profile", "error"]);
+
+  return (
+    <div>
+      <div ref={pageRef}>
+        <ProfileHeader
+          viewedUserName={viewedUserName}
+          profileImageUrl={profileImageUrl}
+          isLoading={isLoading}
+        />
+
+        <EditControls
+          label={
+            isEditing
+              ? t("save", { ns: "profile" })
+              : t("edit", { ns: "profile" })
+          }
+          isEditing={isEditing}
+          toggleEditing={handleToggleEditing}
+          handleSaveChanges={handleSaveChanges}
+        />
+
+        <FavoriteSections
+          sections={sections}
+          isEditing={isEditing}
+          isLoading={isLoading}
+        />
+
+        {isModalOpen && modalType && activeSection && (
+          <SearchModal
+            closeModal={closeModal}
+            modalType={modalType}
+            activeSection={activeSection}
+            handleAddItem={(section, item) => {
+              handleAddItem(section as keyof UserFavorites, item);
+            }}
+            userFavorites={editedFavorites as UserFavorites}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ProfileSection;

--- a/src/features/profile/components/SearchModal.tsx
+++ b/src/features/profile/components/SearchModal.tsx
@@ -81,7 +81,6 @@ const SearchModal = ({
         imageUrl: item.imageUrl,
         artists: item.artists,
         previewUrl: item.previewUrl,
-        durationMs: item.durationMs,
         popularity: item.popularity,
       };
 

--- a/src/features/profile/hooks/useProfileActions.ts
+++ b/src/features/profile/hooks/useProfileActions.ts
@@ -4,36 +4,38 @@ import { useState } from "react";
 
 interface UseProfileActionsProps {
   editedFavorites: UserFavorites | null;
-  setEditedFavorites: React.Dispatch<
-    React.SetStateAction<UserFavorites | null>
-  >;
+  setEditedFavorites: (favorites: UserFavorites | null) => void;
+}
+
+interface ModalState {
+  isOpen: boolean;
+  type?: "artist" | "track";
+  section?: keyof UserFavorites;
 }
 
 const useProfileActions = ({
   editedFavorites,
   setEditedFavorites,
 }: UseProfileActionsProps) => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [modalType, setModalType] = useState<"artist" | "track" | undefined>(
-    undefined,
-  );
-  const [activeSection, setActiveSection] = useState<
-    keyof UserFavorites | undefined
-  >(undefined);
+  const [modalState, setModalState] = useState<ModalState>({
+    isOpen: false,
+  });
 
   const openModal = (
     type: "artist" | "track",
     section: keyof UserFavorites,
   ) => {
-    setModalType(type);
-    setActiveSection(section);
-    setIsModalOpen(true);
+    setModalState({
+      isOpen: true,
+      type,
+      section,
+    });
   };
 
   const closeModal = () => {
-    setIsModalOpen(false);
-    setModalType(undefined);
-    setActiveSection(undefined);
+    setModalState({
+      isOpen: false,
+    });
   };
 
   const handleDelete = <S extends keyof UserFavorites>(
@@ -57,9 +59,9 @@ const useProfileActions = ({
   };
 
   return {
-    isModalOpen,
-    modalType,
-    activeSection,
+    isModalOpen: modalState.isOpen,
+    modalType: modalState.type,
+    activeSection: modalState.section,
     openModal,
     closeModal,
     handleDelete,

--- a/src/features/profile/hooks/useProfileEditing.ts
+++ b/src/features/profile/hooks/useProfileEditing.ts
@@ -1,13 +1,19 @@
 import errorLogger from "@/libs/utils/errorLogger";
 import { AppError, ProfileError } from "@/types/error";
 import { UserFavorites } from "@/types/favorite";
+import { UseMutateFunction } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 import { useState } from "react";
 
 const useProfileEditing = (
   userId: number,
-  userFavorites: UserFavorites | null,
-  saveFavorites: (favorites: UserFavorites) => Promise<void>,
+  userFavorites: UserFavorites | null | undefined,
+  saveFavorites: UseMutateFunction<
+    UserFavorites,
+    Error,
+    UserFavorites,
+    unknown
+  >,
 ) => {
   const { data: session } = useSession();
   const [isEditing, setIsEditing] = useState(false);

--- a/src/features/profile/hooks/useProfileSections.ts
+++ b/src/features/profile/hooks/useProfileSections.ts
@@ -1,43 +1,49 @@
 import { UserFavorites } from "@/types/favorite";
+import { SectionConfig } from "@/types/section";
 import { useTranslation } from "next-i18next";
 
 const useProfileSections = (
   displayFavorites: UserFavorites | null | undefined,
   openModal: (type: "artist" | "track", section: keyof UserFavorites) => void,
-  handleDelete: <S extends keyof UserFavorites>(section: S, id: string) => void,
+  handleDelete: (section: keyof UserFavorites, id: string) => void,
 ) => {
   const { t } = useTranslation("common");
 
-  return [
+  const artistSections: SectionConfig[] = [
     {
       title: t("all_time_favorite_artists"),
-      items: displayFavorites?.allTimeArtists || [],
-      type: "artist" as const,
+      items: displayFavorites?.allTimeArtists ?? [],
+      type: "artist",
       openModal: () => openModal("artist", "allTimeArtists"),
       handleDelete: (id: string) => handleDelete("allTimeArtists", id),
     },
     {
+      title: t("current_favorite_artists"),
+      items: displayFavorites?.currentArtists ?? [],
+      type: "artist",
+      openModal: () => openModal("artist", "currentArtists"),
+      handleDelete: (id: string) => handleDelete("currentArtists", id),
+    },
+  ];
+
+  const trackSections: SectionConfig[] = [
+    {
       title: t("all_time_favorite_tracks"),
-      items: displayFavorites?.allTimeTracks || [],
-      type: "track" as const,
+      items: displayFavorites?.allTimeTracks ?? [],
+      type: "track",
       openModal: () => openModal("track", "allTimeTracks"),
       handleDelete: (id: string) => handleDelete("allTimeTracks", id),
     },
     {
-      title: t("current_favorite_artists"),
-      items: displayFavorites?.currentArtists || [],
-      type: "artist" as const,
-      openModal: () => openModal("artist", "currentArtists"),
-      handleDelete: (id: string) => handleDelete("currentArtists", id),
-    },
-    {
       title: t("current_favorite_tracks"),
-      items: displayFavorites?.currentTracks || [],
-      type: "track" as const,
+      items: displayFavorites?.currentTracks ?? [],
+      type: "track",
       openModal: () => openModal("track", "currentTracks"),
       handleDelete: (id: string) => handleDelete("currentTracks", id),
     },
   ];
+
+  return [...artistSections, ...trackSections];
 };
 
 export default useProfileSections;

--- a/src/features/profile/hooks/useProfileSections.ts
+++ b/src/features/profile/hooks/useProfileSections.ts
@@ -2,9 +2,9 @@ import { UserFavorites } from "@/types/favorite";
 import { useTranslation } from "next-i18next";
 
 const useProfileSections = (
-  displayFavorites: UserFavorites | null,
-  openModal: (type: "artist" | "track", section: string) => void,
-  handleDelete: (section: string, id: string) => void,
+  displayFavorites: UserFavorites | null | undefined,
+  openModal: (type: "artist" | "track", section: keyof UserFavorites) => void,
+  handleDelete: <S extends keyof UserFavorites>(section: S, id: string) => void,
 ) => {
   const { t } = useTranslation("common");
 

--- a/src/features/profile/queries/useUserProfile.ts
+++ b/src/features/profile/queries/useUserProfile.ts
@@ -1,3 +1,5 @@
+import errorLogger from "@/libs/utils/errorLogger";
+import { ProfileError } from "@/types/error";
 import { UserFavorites } from "@/types/favorite";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
@@ -5,6 +7,10 @@ import axios from "axios";
 interface UserData {
   name: string;
   profileImage: string | null;
+}
+
+interface MutationContext {
+  previousFavorites?: UserFavorites;
 }
 
 export const fetchUserFavorites = async (
@@ -57,7 +63,12 @@ const useUserProfile = (userId: number) => {
     staleTime: 5 * 60 * 1000,
   });
 
-  const mutation = useMutation<UserFavorites, Error, UserFavorites, unknown>({
+  const mutation = useMutation<
+    UserFavorites,
+    Error,
+    UserFavorites,
+    MutationContext
+  >({
     mutationFn: async (newFavorites: UserFavorites) => {
       const response = await axios.patch<UserFavorites>("/api/user-favorites", {
         userId,
@@ -77,8 +88,40 @@ const useUserProfile = (userId: number) => {
 
       return { previousFavorites };
     },
-    onError: (error: unknown) => {
-      JSON.stringify(error);
+    onError: (
+      error: Error,
+      failedUpdate: UserFavorites,
+      context: MutationContext | undefined,
+    ) => {
+      errorLogger(
+        new ProfileError(
+          "Failed to save favorites",
+          {
+            severity: "error",
+            statusCode: 500,
+            componentStack: "useUserProfile.mutation",
+          },
+          {
+            originalError: error.message,
+            userId,
+            action: "saveFavorites",
+            failedUpdate: {
+              allTimeArtistsCount: failedUpdate.allTimeArtists.length,
+              allTimeTracksCount: failedUpdate.allTimeTracks.length,
+              currentArtistsCount: failedUpdate.currentArtists.length,
+              currentTracksCount: failedUpdate.currentTracks.length,
+            },
+          },
+        ),
+      );
+
+      // 이전 상태로 복구
+      if (context?.previousFavorites) {
+        queryClient.setQueryData(
+          ["userFavorites", userId],
+          context.previousFavorites,
+        );
+      }
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["userFavorites", userId] });

--- a/src/features/search/components/SearchResultItem.tsx
+++ b/src/features/search/components/SearchResultItem.tsx
@@ -1,5 +1,3 @@
-import PauseIcon from "@/assets/icons/pause.svg";
-import PlayIcon from "@/assets/icons/play.svg";
 import TImage from "@/features/common/components/TImage";
 import {
   SearchResult,
@@ -13,18 +11,9 @@ import { useTranslation } from "react-i18next";
 interface SearchResultItemProps {
   result: SearchResult;
   listType: "artist" | "track" | "album";
-  isPlaying?: boolean;
-  onPlay?: () => void;
-  isCurrent?: boolean;
 }
 
-const SearchResultItem = ({
-  result,
-  listType,
-  isPlaying = false,
-  onPlay,
-  isCurrent = false,
-}: SearchResultItemProps) => {
+const SearchResultItem = ({ result, listType }: SearchResultItemProps) => {
   const { t } = useTranslation("common");
 
   // 타입 가드 함수 정의
@@ -54,9 +43,7 @@ const SearchResultItem = ({
   };
 
   return (
-    <li
-      className={`flex items-center justify-between text-sm text-white cursor-pointer ${isCurrent ? "bg-zinc-950" : "bg-zinc-900"} hover:bg-gray-700 p-2 rounded-lg`}
-    >
+    <li className="flex items-center justify-between text-sm text-white cursor-pointer bg-zinc-900 hover:bg-gray-700 p-2 rounded-lg">
       <Link
         href={getDetailPageUrl()}
         passHref
@@ -85,18 +72,6 @@ const SearchResultItem = ({
             )}
           </div>
         </div>
-        {listType === "track" && isTrack(result) && result.previewUrl && (
-          <button
-            onClick={(e) => {
-              e.preventDefault();
-              onPlay?.();
-            }}
-            className="sm:px-2 text-neonBlue hover:text-chefchaouenBlue focus:outline-none"
-            type="button"
-          >
-            {isCurrent && isPlaying ? <PauseIcon /> : <PlayIcon />}
-          </button>
-        )}
       </Link>
     </li>
   );

--- a/src/features/track/hooks/useTrackPlayer.ts
+++ b/src/features/track/hooks/useTrackPlayer.ts
@@ -19,7 +19,6 @@ const useTrackPlayer = (track: TrackDetail) => {
       imageUrl: track.album.images[0]?.url || "/default-album.png",
       artists: track.artists,
       previewUrl: track.preview_url,
-      durationMs: track.duration_ms,
       popularity: track.popularity,
     });
 

--- a/src/pages/api/advanced-search.ts
+++ b/src/pages/api/advanced-search.ts
@@ -34,7 +34,6 @@ const simplifyTracks = (tracks: SpotifyTrack[]): SimplifiedTrack[] => {
       .map((artist: SpotifyArtistBrief) => artist.name)
       .join(", "),
     previewUrl: track.preview_url,
-    durationMs: track.duration_ms,
     popularity: track.popularity,
   }));
 };

--- a/src/pages/api/album/[albumId].ts
+++ b/src/pages/api/album/[albumId].ts
@@ -36,7 +36,6 @@ const simplifyAlbumData = (data: SpotifyAlbum): SimplifiedAlbum => {
           name: artist.name,
         })),
         previewUrl: track.preview_url,
-        durationMs: track.duration_ms,
         imageUrl,
         popularity: track.popularity,
       })),

--- a/src/pages/api/artist/[artistId].ts
+++ b/src/pages/api/artist/[artistId].ts
@@ -138,7 +138,6 @@ const handler = async (
             name: artist.name,
           })),
           previewUrl: track.preview_url,
-          durationMs: track.duration_ms,
           popularity: track.popularity,
         })),
       },

--- a/src/pages/api/likes.ts
+++ b/src/pages/api/likes.ts
@@ -153,7 +153,6 @@ const handleGet = async (
                 imageUrl: fav.track.imageUrl,
                 artists: fav.track.artists,
                 previewUrl: fav.track.previewUrl,
-                durationMs: fav.track.durationMs,
                 popularity: fav.track.popularity,
               })),
               href: `/api/likes?userId=${userIdInt}&type=track&limit=${parsedLimit}&offset=${parsedOffset}`,
@@ -233,7 +232,6 @@ const handlePost = async (
     artists,
     followers,
     previewUrl,
-    durationMs,
     popularity,
     releaseDate,
   } = req.body;
@@ -289,7 +287,6 @@ const handlePost = async (
                 imageUrl,
                 artists,
                 previewUrl,
-                durationMs,
                 popularity,
               },
             });

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -79,7 +79,6 @@ const handler = async (
             .join(", "),
           id: track.id,
           previewUrl: track.preview_url,
-          durationMs: track.duration_ms,
           popularity: track.popularity,
         }),
       );

--- a/src/pages/api/user-favorites.ts
+++ b/src/pages/api/user-favorites.ts
@@ -181,7 +181,6 @@ const handlePatch = async (
           imageUrl: track.imageUrl,
           artists: track.artists,
           previewUrl: track.previewUrl,
-          durationMs: track.durationMs,
           popularity: track.popularity,
         }));
 

--- a/src/pages/liked/index.tsx
+++ b/src/pages/liked/index.tsx
@@ -1,10 +1,18 @@
 import LikedSection from "@/features/liked/components/LikedSection";
+import LikedSEO from "@/features/liked/components/LikedSEO";
 import { GetServerSideProps } from "next";
+import { useSession } from "next-auth/react";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 const LikedPage = () => {
+  const { data: session } = useSession();
+
   return (
     <div className="max-w-4xl mx-auto p-6 mt-6 bg-zinc-800 rounded-lg shadow-md">
+      <LikedSEO
+        userName={session?.user?.name}
+        userProfileImage={session?.user?.image}
+      />
       <LikedSection />
     </div>
   );

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -14,20 +14,14 @@ import { ProfileError } from "@/types/error";
 import { dehydrate, QueryClient } from "@tanstack/react-query";
 import { GetServerSideProps } from "next";
 import { getSession } from "next-auth/react";
-import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useRef } from "react";
-
-interface ProfileErrorInfo {
-  componentStack: string;
-}
 
 interface ProfilePageProps {
   userId: number;
 }
 
 const ProfilePage = ({ userId }: ProfilePageProps) => {
-  const { t } = useTranslation(["common", "profile", "error"]);
   const pageRef = useRef<HTMLDivElement>(null);
 
   const {

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,27 +1,22 @@
 import ErrorComponent from "@/features/common/components/ErrorComponent";
-import EditControls from "@/features/profile/components/EditControls";
-import FavoriteSections from "@/features/profile/components/FavoriteSections";
-import ProfileHeader from "@/features/profile/components/ProfileHeader";
-import SearchModal from "@/features/profile/components/SearchModal";
+import ProfileSection from "@/features/profile/components/ProfileSection";
+import ProfileSEO from "@/features/profile/components/ProfileSEO";
 import useProfileActions from "@/features/profile/hooks/useProfileActions";
+import useProfileEditing from "@/features/profile/hooks/useProfileEditing";
+import useProfileSections from "@/features/profile/hooks/useProfileSections";
 import useUserProfile, {
   fetchUserData,
   fetchUserFavorites,
 } from "@/features/profile/queries/useUserProfile";
 import errorLogger from "@/libs/utils/errorLogger";
+import handlePageError from "@/libs/utils/handlePageError";
 import { ProfileError } from "@/types/error";
-import {
-  UserFavoriteArtist,
-  UserFavorites,
-  UserFavoriteTrack,
-} from "@/types/favorite";
 import { dehydrate, QueryClient } from "@tanstack/react-query";
 import { GetServerSideProps } from "next";
-import { getSession, useSession } from "next-auth/react";
+import { getSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { NextSeo } from "next-seo";
-import { useRef, useState } from "react";
+import { useRef } from "react";
 
 interface ProfileErrorInfo {
   componentStack: string;
@@ -33,7 +28,7 @@ interface ProfilePageProps {
 
 const ProfilePage = ({ userId }: ProfilePageProps) => {
   const { t } = useTranslation(["common", "profile", "error"]);
-  const { data: session } = useSession();
+  const pageRef = useRef<HTMLDivElement>(null);
 
   const {
     userFavorites,
@@ -45,10 +40,14 @@ const ProfilePage = ({ userId }: ProfilePageProps) => {
     saveFavorites,
   } = useUserProfile(userId);
 
-  const [isEditing, setIsEditing] = useState(false);
-  const [editedFavorites, setEditedFavorites] = useState<UserFavorites | null>(
-    null,
-  );
+  const {
+    isEditing,
+    editedFavorites,
+    setEditedFavorites,
+    handleToggleEditing,
+    handleSaveChanges,
+    displayFavorites,
+  } = useProfileEditing(userId, userFavorites, saveFavorites);
 
   const {
     isModalOpen,
@@ -63,173 +62,45 @@ const ProfilePage = ({ userId }: ProfilePageProps) => {
     setEditedFavorites,
   });
 
-  const pageRef = useRef<HTMLDivElement>(null);
-
-  const handleToggleEditing = () => {
-    try {
-      if (!session?.user?.id || session.user.id !== userId) {
-        throw new ProfileError("Unauthorized editing attempt", {
-          userId,
-          sessionUserId: session?.user?.id,
-          action: "toggleEditing",
-        });
-      }
-
-      if (!isEditing) {
-        // 편집 모드로 전환될 때, 현재 favorites를 로컬 상태로 복사
-        setEditedFavorites(userFavorites ? { ...userFavorites } : null);
-      } else {
-        // 편집 모드에서 나올 때, 로컬 상태 초기화
-        setEditedFavorites(null);
-      }
-      setIsEditing((prev) => !prev);
-    } catch (error) {
-      if (error instanceof Error) {
-        errorLogger(error, {
-          componentStack: "ProfilePage.handleToggleEditing",
-        } as ProfileErrorInfo);
-      }
-    }
-  };
-
-  // 편집 모드일 때는 editedFavorites를, 아닐 때는 userFavorites를 사용
-  const displayFavorites =
-    isEditing && editedFavorites ? editedFavorites : userFavorites;
-
-  const handleSaveChanges = async () => {
-    try {
-      if (!session?.user?.id || !editedFavorites) {
-        throw new ProfileError("Invalid save attempt", {
-          userId,
-          hasSession: !!session?.user?.id,
-          hasEditedFavorites: !!editedFavorites,
-          action: "saveChanges",
-        });
-      }
-
-      await saveFavorites(editedFavorites);
-      setIsEditing(false);
-      setEditedFavorites(null);
-    } catch (error) {
-      if (error instanceof Error) {
-        errorLogger(error, {
-          componentStack: "ProfilePage.handleSaveChanges",
-        } as ProfileErrorInfo);
-      }
-    }
-  };
-
-  const viewedUserName = userData?.name;
-  const profileImageUrl = userData?.profileImage;
+  const sections = useProfileSections(
+    displayFavorites,
+    openModal,
+    handleDelete,
+  );
 
   if (userFavoritesError || userDataError) {
-    return (
-      <ErrorComponent
-        message={`Error loading data: ${userFavoritesError?.message || userDataError?.message}`}
-      />
-    );
+    const errorMessage = handlePageError(userFavoritesError || userDataError);
+    return <ErrorComponent message={errorMessage} />;
   }
 
   const isLoading = isFavoritesLoading || isUserDataLoading;
 
-  const sections: {
-    title: string;
-    items: UserFavoriteArtist[] | UserFavoriteTrack[];
-    type: "artist" | "track";
-    openModal: () => void;
-    handleDelete: (id: string) => void;
-  }[] = [
-    {
-      title: t("all_time_favorite_artists"),
-      items: displayFavorites?.allTimeArtists || [],
-      type: "artist",
-      openModal: () => openModal("artist", "allTimeArtists"),
-      handleDelete: (id: string) => handleDelete("allTimeArtists", id),
-    },
-    {
-      title: t("all_time_favorite_tracks"),
-      items: displayFavorites?.allTimeTracks || [],
-      type: "track",
-      openModal: () => openModal("track", "allTimeTracks"),
-      handleDelete: (id: string) => handleDelete("allTimeTracks", id),
-    },
-    {
-      title: t("current_favorite_artists"),
-      items: displayFavorites?.currentArtists || [],
-      type: "artist",
-      openModal: () => openModal("artist", "currentArtists"),
-      handleDelete: (id: string) => handleDelete("currentArtists", id),
-    },
-    {
-      title: t("current_favorite_tracks"),
-      items: displayFavorites?.currentTracks || [],
-      type: "track",
-      openModal: () => openModal("track", "currentTracks"),
-      handleDelete: (id: string) => handleDelete("currentTracks", id),
-    },
-  ];
+  const viewedUserName = userData?.name;
+  const profileImageUrl = userData?.profileImage;
 
   return (
     <div className="max-w-4xl mx-auto p-6 mt-6 bg-zinc-800 rounded-lg shadow-md">
-      <NextSeo
-        title={`${viewedUserName} - Track List Now`}
-        description={`${viewedUserName}'s favorite artists and tracks on Track List Now`}
-        openGraph={{
-          type: "profile",
-          url: `https://www.tracklistnow.com/profile/${userId}`,
-          title: `${viewedUserName} - Track List Now`,
-          description: `${viewedUserName}'s favorite artists and tracks`,
-          images: [
-            {
-              url: profileImageUrl || "/default-profile-image.jpg",
-              width: 800,
-              height: 800,
-              alt: `${profileImageUrl}'s Profile Image`,
-            },
-          ],
-        }}
-        twitter={{
-          handle: "@TrackListNow",
-          site: "@TrackListNow",
-          cardType: "summary_large_image",
-        }}
+      <ProfileSEO
+        viewedUserName={viewedUserName}
+        profileImageUrl={profileImageUrl}
+        userId={userId}
       />
-      <div ref={pageRef}>
-        <ProfileHeader
-          profileImageUrl={profileImageUrl}
-          viewedUserName={viewedUserName}
-          isLoading={isLoading}
-        />
-
-        <EditControls
-          label={
-            isEditing
-              ? t("save", { ns: "profile" })
-              : t("edit", { ns: "profile" })
-          }
-          isEditing={isEditing}
-          toggleEditing={handleToggleEditing}
-          handleSaveChanges={handleSaveChanges}
-        />
-
-        <FavoriteSections
-          sections={sections}
-          isEditing={isEditing}
-          isLoading={isLoading}
-        />
-
-        {isModalOpen && modalType && activeSection && (
-          <SearchModal
-            closeModal={closeModal}
-            modalType={modalType}
-            activeSection={activeSection}
-            handleAddItem={(section, item) => {
-              handleAddItem(section as keyof UserFavorites, item);
-            }}
-            userFavorites={editedFavorites as UserFavorites}
-          />
-        )}
-      </div>
+      <ProfileSection
+        viewedUserName={userData?.name}
+        profileImageUrl={userData?.profileImage}
+        isLoading={isLoading}
+        isEditing={isEditing}
+        editedFavorites={editedFavorites}
+        sections={sections}
+        pageRef={pageRef}
+        isModalOpen={isModalOpen}
+        modalType={modalType}
+        activeSection={activeSection}
+        handleToggleEditing={handleToggleEditing}
+        handleSaveChanges={handleSaveChanges}
+        closeModal={closeModal}
+        handleAddItem={handleAddItem}
+      />
     </div>
   );
 };

--- a/src/types/album.ts
+++ b/src/types/album.ts
@@ -39,7 +39,6 @@ export interface SimplifiedTrack {
   artists: SimplifiedArtist[];
   imageUrl: string;
   previewUrl: string | null;
-  durationMs: number;
   popularity: number;
 }
 

--- a/src/types/favorite.ts
+++ b/src/types/favorite.ts
@@ -13,7 +13,6 @@ export interface UserFavoriteTrack {
   imageUrl: string;
   artists: string;
   previewUrl: string | null;
-  durationMs: number;
   popularity: number;
 }
 
@@ -99,7 +98,6 @@ export interface UserFavoriteTrackInput {
   imageUrl: string;
   artists: string;
   previewUrl: string | null;
-  durationMs: number;
   popularity: number;
 }
 

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -14,7 +14,6 @@ export interface SimplifiedTrack {
   imageUrl: string;
   artists: string;
   previewUrl: string | null;
-  durationMs: number;
   popularity: number;
 }
 
@@ -99,7 +98,6 @@ export interface AddedTrack {
   imageUrl: string;
   artists: string;
   previewUrl: string | null;
-  durationMs: number;
   popularity: number;
 }
 

--- a/src/types/section.ts
+++ b/src/types/section.ts
@@ -1,0 +1,43 @@
+import {
+  UserFavoriteArtist,
+  UserFavoriteTrack,
+  UserFavorites,
+} from "@/types/favorite";
+
+export interface BaseSection {
+  title: string;
+  type: "artist" | "track";
+  openModal: () => void;
+  handleDelete: (id: string) => void;
+}
+
+export interface ArtistSection extends BaseSection {
+  type: "artist";
+  items: UserFavoriteArtist[];
+}
+
+export interface TrackSection extends BaseSection {
+  type: "track";
+  items: UserFavoriteTrack[];
+}
+
+export type SectionConfig = ArtistSection | TrackSection;
+
+export interface ProfileSectionProps {
+  viewedUserName?: string;
+  profileImageUrl?: string | null;
+  isLoading: boolean;
+  isEditing: boolean;
+  editedFavorites: UserFavorites | null;
+  sections: SectionConfig[];
+  isModalOpen: boolean;
+  modalType?: "artist" | "track" | null;
+  activeSection?: string | null;
+  handleToggleEditing: () => void;
+  handleSaveChanges: () => Promise<void>;
+  closeModal: () => void;
+  handleAddItem: (
+    section: keyof UserFavorites,
+    item: UserFavoriteArtist | UserFavoriteTrack,
+  ) => void;
+}


### PR DESCRIPTION
1. [Fix: album 페이지와 aritst 페이지에서 track을 미리듣기하다가 like 버튼을 누를 때 제대로 동작하지 않던…](https://github.com/jihohub/track-list-now/commit/1919047a1b6eabfc0701c5f908ba3c028de296d0)
2. [Fix: track 테이블에서 durationMs 컬럼 제거](https://github.com/jihohub/track-list-now/commit/6546a966eefd5e61604a01deb0022c483d744b5e)
3. [Refactor: 프로필 페이지 컴포넌트 분리](https://github.com/jihohub/track-list-now/commit/fe2868230aef1aa2119422f3866de216c3978aa6)
4. [Refactor: profile 페이지와 liked 페이지의 SEO 수정](https://github.com/jihohub/track-list-now/commit/260845b41961f935a3241c027ff6efbf0c5fa539)