### PR TITLE
Design: 모바일 버전에서 프로필 페이지의 FavoriteItem 컴포넌트의 아이콘 크기가 비정상적으로 크게 나오는 현상 수정

### DIFF
--- a/src/features/profile/components/FavoriteItem.tsx
+++ b/src/features/profile/components/FavoriteItem.tsx
@@ -41,7 +41,7 @@ const FavoriteItem = ({
                   : (item as UserFavoriteTrack).trackId,
               );
             }}
-            className={`absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 text-white text-3xl ${
+            className={`absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 text-white text-xl sm:text-3xl ${
               type === "artist" ? "rounded-full" : "rounded-lg"
             }`}
             type="button"

--- a/src/features/profile/components/FavoriteSection.tsx
+++ b/src/features/profile/components/FavoriteSection.tsx
@@ -42,7 +42,7 @@ const FavoriteSection = ({
           >
             <button
               onClick={isEditing ? openModal : undefined}
-              className={`flex items-center justify-center w-24 h-24 ${
+              className={`flex items-center justify-center w-16 h-16 sm:w-24 sm:h-24 ${
                 type === "track" ? "rounded-lg" : "rounded-full"
               }`}
               style={{
@@ -53,11 +53,11 @@ const FavoriteSection = ({
               type="button"
             >
               {isEditing ? (
-                <AddIcon className="w-8 h-8 text-white" />
+                <AddIcon className="w-6 h-6 sm:w-8 sm:h-8 text-white" />
               ) : type === "artist" ? (
-                <ArtistIcon className="w-8 h-8 text-gray-500" />
+                <ArtistIcon className="w-6 h-6 sm:w-8 sm:h-8 text-gray-500" />
               ) : (
-                <TrackIcon className="w-8 h-8 text-gray-500" />
+                <TrackIcon className="w-6 h-6 sm:w-8 sm:h-8 text-gray-500" />
               )}
             </button>
           </div>

--- a/src/features/profile/hooks/useProfileSections.ts
+++ b/src/features/profile/hooks/useProfileSections.ts
@@ -9,7 +9,7 @@ const useProfileSections = (
 ) => {
   const { t } = useTranslation("common");
 
-  const artistSections: SectionConfig[] = [
+  const allTimeSections: SectionConfig[] = [
     {
       title: t("all_time_favorite_artists"),
       items: displayFavorites?.allTimeArtists ?? [],
@@ -18,21 +18,21 @@ const useProfileSections = (
       handleDelete: (id: string) => handleDelete("allTimeArtists", id),
     },
     {
-      title: t("current_favorite_artists"),
-      items: displayFavorites?.currentArtists ?? [],
-      type: "artist",
-      openModal: () => openModal("artist", "currentArtists"),
-      handleDelete: (id: string) => handleDelete("currentArtists", id),
-    },
-  ];
-
-  const trackSections: SectionConfig[] = [
-    {
       title: t("all_time_favorite_tracks"),
       items: displayFavorites?.allTimeTracks ?? [],
       type: "track",
       openModal: () => openModal("track", "allTimeTracks"),
       handleDelete: (id: string) => handleDelete("allTimeTracks", id),
+    },
+  ];
+
+  const currentSections: SectionConfig[] = [
+    {
+      title: t("current_favorite_artists"),
+      items: displayFavorites?.currentArtists ?? [],
+      type: "artist",
+      openModal: () => openModal("artist", "currentArtists"),
+      handleDelete: (id: string) => handleDelete("currentArtists", id),
     },
     {
       title: t("current_favorite_tracks"),
@@ -43,7 +43,7 @@ const useProfileSections = (
     },
   ];
 
-  return [...artistSections, ...trackSections];
+  return [...allTimeSections, ...currentSections];
 };
 
 export default useProfileSections;


### PR DESCRIPTION
1. [Design: 모바일 버전에서 프로필 페이지의 FavoriteItem 컴포넌트의 아이콘 크기가 비정상적으로 크게 나오는 현상 수정](https://github.com/jihohub/track-list-now/commit/73899bacc29d9579d0ccfdb57fc9a0a2e20e738b)
2. [Fix: 프로필 페이지에서 섹션의 순서가 기획한 대로 나오도록 수정](https://github.com/jihohub/track-list-now/commit/318dd3138c09346173e68cab19ef3297f4306609)