### PR TITLE
Feat: 아티스트 페이지에서 인기 트랙, 앨범, 연관 아티스트를 탭별로 보여주도록 변경

### DIFF
--- a/public/locales/en/artist.json
+++ b/public/locales/en/artist.json
@@ -1,4 +1,5 @@
 {
   "top_tracks": "Top tracks",
+  "albums": "Albums",
   "related_artists": "Related artists"
 }

--- a/public/locales/ko/artist.json
+++ b/public/locales/ko/artist.json
@@ -1,4 +1,5 @@
 {
   "top_tracks": "인기 트랙",
+  "albums": "앨범",
   "related_artists": "연관 아티스트"
 }

--- a/src/features/album/components/AlbumSection.tsx
+++ b/src/features/album/components/AlbumSection.tsx
@@ -22,6 +22,8 @@ const AlbumSection = ({ album }: AlbumSectionProps) => {
     handleNext,
     handleClosePlayer,
     currentTrack,
+    disablePrevious,
+    disableNext,
   } = useAlbumPlayer(album);
 
   return (
@@ -65,6 +67,8 @@ const AlbumSection = ({ album }: AlbumSectionProps) => {
         volume={volume}
         setVolume={setVolume}
         enableClose
+        disablePrevious={disablePrevious}
+        disableNext={disableNext}
       />
     </div>
   );

--- a/src/features/album/hooks/useAlbumPlayer.ts
+++ b/src/features/album/hooks/useAlbumPlayer.ts
@@ -42,7 +42,9 @@ const useAlbumPlayer = (album: SimplifiedAlbum) => {
       const currentPlayableIndex = playableTracks.findIndex(
         (index) => index === currentIndex,
       );
-      return playableTracks[currentPlayableIndex + 1];
+      return currentPlayableIndex < playableTracks.length - 1
+        ? playableTracks[currentPlayableIndex + 1]
+        : undefined;
     },
     [getPlayableTracks],
   );
@@ -53,10 +55,30 @@ const useAlbumPlayer = (album: SimplifiedAlbum) => {
       const currentPlayableIndex = playableTracks.findIndex(
         (index) => index === currentIndex,
       );
-      return playableTracks[currentPlayableIndex - 1];
+      return currentPlayableIndex > 0
+        ? playableTracks[currentPlayableIndex - 1]
+        : undefined;
     },
     [getPlayableTracks],
   );
+
+  const getNavigationState = useCallback(() => {
+    if (currentTrackIndex === null) {
+      return { disablePrevious: true, disableNext: true };
+    }
+
+    const playableTracks = getPlayableTracks();
+    const currentPlayableIndex = playableTracks.findIndex(
+      (index) => index === currentTrackIndex,
+    );
+
+    return {
+      disablePrevious: currentPlayableIndex <= 0,
+      disableNext:
+        currentPlayableIndex >= playableTracks.length - 1 ||
+        findNextPlayableTrack(currentTrackIndex) === undefined,
+    };
+  }, [currentTrackIndex, getPlayableTracks, findNextPlayableTrack]);
 
   const handlePlay = (index: number) => {
     if (currentTrackIndex === index) {
@@ -94,6 +116,7 @@ const useAlbumPlayer = (album: SimplifiedAlbum) => {
 
   const currentTrack =
     currentTrackIndex !== null ? album.tracks.items[currentTrackIndex] : null;
+  const { disablePrevious, disableNext } = getNavigationState();
 
   return {
     currentTrackIndex,
@@ -106,6 +129,8 @@ const useAlbumPlayer = (album: SimplifiedAlbum) => {
     handleNext,
     handleClosePlayer,
     currentTrack,
+    disablePrevious,
+    disableNext,
   };
 };
 

--- a/src/features/artist/components/AlbumsTab.tsx
+++ b/src/features/artist/components/AlbumsTab.tsx
@@ -1,0 +1,58 @@
+import useArtistAlbums from "@/features/artist/queries/useArtistAlbums";
+import GlobalLoadingBar from "@/features/common/components/GlobalLoadingBar";
+import SearchResultItem from "@/features/search/components/SearchResultItem";
+import { useTranslation } from "next-i18next";
+import InfiniteScroll from "react-infinite-scroll-component";
+
+interface AlbumsTabProps {
+  artistId: string;
+}
+
+const AlbumsTab = ({ artistId }: AlbumsTabProps) => {
+  const { t } = useTranslation(["artist"]);
+  const { data, isLoading, isError, fetchNextPage, hasNextPage } =
+    useArtistAlbums({
+      artistId,
+      enabled: true,
+    });
+
+  if (isLoading) return <GlobalLoadingBar />;
+  if (isError)
+    return <div className="text-red-500">{t("error.loading_albums")}</div>;
+
+  const albums = data?.pages.flatMap((page) => page.items) ?? [];
+
+  if (!albums.length) {
+    return <div className="text-gray-400 text-center">{t("no_albums")}</div>;
+  }
+
+  return (
+    <div className="mt-6">
+      <h2 className="text-2xl font-semibold text-white mb-4">{t("albums")}</h2>
+      <InfiniteScroll
+        dataLength={albums.length}
+        next={() => fetchNextPage()}
+        hasMore={hasNextPage ?? false}
+        loader={<GlobalLoadingBar />}
+      >
+        <ul className="space-y-2">
+          {albums.map((album) => (
+            <SearchResultItem
+              key={album.id}
+              result={{
+                id: album.id,
+                name: album.name,
+                imageUrl: album.images[0]?.url,
+                artists: album.artists.map((artist) => artist.name).join(", "),
+                releaseDate: album.release_date,
+              }}
+              listType="album"
+            />
+          ))}
+        </ul>
+      </InfiniteScroll>
+    </div>
+  );
+};
+
+export default AlbumsTab;

--- a/src/features/artist/components/ArtistSection.tsx
+++ b/src/features/artist/components/ArtistSection.tsx
@@ -1,139 +1,49 @@
-import TopTrackItem from "@/features/artist/components/TopTrackItem";
-import useArtistPlayer from "@/features/artist/hooks/useArtistPlayer";
-import AudioPlayer from "@/features/audio/components/AudioPlayer";
-import TImage from "@/features/common/components/TImage";
+import AlbumsTab from "@/features/artist/components/AlbumsTab";
+import ArtistTabs from "@/features/artist/components/ArtistTabs";
+import OverviewSection from "@/features/artist/components/OverviewSection";
+import RelatedArtistsTab from "@/features/artist/components/RelatedArtistsTab";
+import TopTracksTab from "@/features/artist/components/TopTracksTab";
 import { ArtistPageData } from "@/types/artist";
-import { useTranslation } from "next-i18next";
-import Link from "next/link";
-import LikeButton from "../../liked/components/LikeButton";
+import { useRouter } from "next/router";
 
 interface ArtistSectionProps {
   data: ArtistPageData;
+  artistId: string;
 }
 
-const ArtistSection = ({ data }: ArtistSectionProps) => {
-  const { t } = useTranslation(["common", "artist"]);
-  const { artist, topTracks, relatedArtists } = data;
+const ArtistSection = ({ data, artistId }: ArtistSectionProps) => {
+  const router = useRouter();
+  const { tab = "top_tracks" } = router.query;
 
-  const {
-    currentTrackIndex,
-    isPlaying,
-    volume,
-    setVolume,
-    setIsPlaying,
-    handlePlay,
-    handlePrevious,
-    handleNext,
-    handleClosePlayer,
-    currentTrack,
-  } = useArtistPlayer(data);
+  const handleTabChange = (newTab: string) => {
+    const query = { ...router.query, tab: newTab };
+    router.push(
+      {
+        pathname: router.pathname,
+        query,
+      },
+      undefined,
+      { shallow: true },
+    );
+  };
+
+  const renderTabContent = () => {
+    switch (tab) {
+      case "albums":
+        return <AlbumsTab artistId={artistId} />;
+      case "related_artists":
+        return <RelatedArtistsTab artistId={artistId} />;
+      case "top_tracks":
+      default:
+        return <TopTracksTab tracks={data.topTracks.tracks} />;
+    }
+  };
 
   return (
-    <div
-      className={`flex flex-col items-center ${currentTrack && "pb-60 md:pb-40 desktop:pb-20"}`}
-    >
-      {/* 아티스트 기본 정보 */}
-      <div className="relative w-[300px] h-[300px] rounded-full overflow-hidden">
-        <TImage
-          imageUrl={artist.images[0]?.url || "/default-image.jpg"}
-          type="artist"
-          alt={artist.name}
-          size="w-[300px] h-[300px]"
-          className="rounded-full overflow-hidden"
-        />
-      </div>
-      <h1 className="text-2xl font-bold text-white mt-4">{artist.name}</h1>
-      <div className="flex justify-center items-center h-20">
-        <LikeButton
-          itemType="artist"
-          itemId={artist.id}
-          name={artist.name}
-          imageUrl={artist.images[0].url}
-          followers={artist.followers.total}
-        />
-      </div>
-
-      <div className="w-full max-w-4xl">
-        {/* Genres: 각 장르를 스타일링된 태그로 감싸기 */}
-        <div className="flex flex-wrap justify-center mt-2 space-x-2">
-          {artist.genres.length > 0 ? (
-            artist.genres.map((genre) => (
-              <span
-                key={genre}
-                className="bg-gray-700 text-gray-300 px-3 py-1 rounded-md text-sm mb-2"
-              >
-                {genre}
-              </span>
-            ))
-          ) : (
-            <span className="bg-gray-700 text-gray-300 px-3 py-1 rounded-md text-sm mb-2">
-              N/A
-            </span>
-          )}
-        </div>
-      </div>
-
-      {/* 탑 트랙 섹션 */}
-      <div className="w-full max-w-4xl mt-8">
-        <h2 className="text-2xl font-semibold text-white mb-4">
-          {t("top_tracks", { ns: "artist" })}
-        </h2>
-        <ul className="space-y-4">
-          {topTracks.tracks.map((track, index) => (
-            <TopTrackItem
-              key={track.id}
-              index={index}
-              track={track}
-              onPlay={() => handlePlay(index)}
-              isCurrent={currentTrackIndex === index}
-              isPlaying={isPlaying}
-            />
-          ))}
-        </ul>
-      </div>
-
-      {/* 연관 아티스트 섹션 */}
-      <div className="w-full max-w-4xl mt-8">
-        <h2 className="text-2xl font-semibold text-white mb-4">
-          {t("related_artists", { ns: "artist" })}
-        </h2>
-        <ul className="grid grid-cols-2 md:grid-cols-4 gap-6">
-          {relatedArtists.artists.map((relatedArtist) => (
-            <li key={relatedArtist.id} className="flex flex-col items-center">
-              <Link
-                href={`/artist/${relatedArtist.id}`}
-                className="flex flex-col items-center"
-              >
-                <div className="relative w-24 h-24">
-                  <TImage
-                    imageUrl={
-                      relatedArtist.images[0]?.url || "/default-image.jpg"
-                    }
-                    type="artist"
-                    alt={relatedArtist.name}
-                    size="w-24 h-24"
-                    className="rounded-full object-cover"
-                  />
-                </div>
-                <span className="text-white mt-3 text-center font-medium">
-                  {relatedArtist.name}
-                </span>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </div>
-      <AudioPlayer
-        track={currentTrack}
-        isPlaying={isPlaying}
-        setIsPlaying={setIsPlaying}
-        onPrevious={handlePrevious}
-        onNext={handleNext}
-        onClose={handleClosePlayer}
-        volume={volume}
-        setVolume={setVolume}
-        enableClose
-      />
+    <div>
+      <OverviewSection artist={data.artist} />
+      <ArtistTabs currentTab={tab as string} onTabChange={handleTabChange} />
+      <div className="mt-6">{renderTabContent()}</div>
     </div>
   );
 };

--- a/src/features/artist/components/ArtistTabs.tsx
+++ b/src/features/artist/components/ArtistTabs.tsx
@@ -1,0 +1,38 @@
+// import TopTracksTab from "@/features/artist/components/TopTracksTab";
+import { useTranslation } from "next-i18next";
+
+interface ArtistTabsProps {
+  currentTab: string;
+  onTabChange: (tab: string) => void;
+}
+
+const ArtistTabs = ({ currentTab, onTabChange }: ArtistTabsProps) => {
+  const { t } = useTranslation(["artist"]);
+
+  const tabs = [
+    { label: "top_tracks", value: "top_tracks" },
+    { label: "albums", value: "albums" },
+    { label: "related_artists", value: "related_artists" },
+  ];
+
+  return (
+    <div className="flex space-x-2 mt-8">
+      {tabs.map((tab) => (
+        <button
+          key={tab.value}
+          onClick={() => onTabChange(tab.value)}
+          className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+            currentTab === tab.value
+              ? "bg-persianBlue text-white"
+              : "bg-gray-700 text-gray-300 hover:bg-gray-600"
+          }`}
+          type="button"
+        >
+          {t(tab.label)}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default ArtistTabs;

--- a/src/features/artist/components/OverviewSection.tsx
+++ b/src/features/artist/components/OverviewSection.tsx
@@ -1,0 +1,45 @@
+import TImage from "@/features/common/components/TImage";
+import LikeButton from "@/features/liked/components/LikeButton";
+import { ArtistPageData } from "@/types/artist";
+
+interface OverviewSectionProps {
+  artist: ArtistPageData["artist"];
+}
+
+const OverviewSection = ({ artist }: OverviewSectionProps) => {
+  return (
+    <div className="flex flex-col items-center">
+      <div className="relative w-[300px] h-[300px] rounded-full overflow-hidden">
+        <TImage
+          imageUrl={artist.images[0]?.url || "/default-image.jpg"}
+          type="artist"
+          alt={artist.name}
+          size="w-[300px] h-[300px]"
+          className="rounded-full"
+        />
+      </div>
+      <h1 className="text-2xl font-bold text-white mt-4">{artist.name}</h1>
+      <div className="flex justify-center items-center h-20">
+        <LikeButton
+          itemType="artist"
+          itemId={artist.id}
+          name={artist.name}
+          imageUrl={artist.images[0]?.url}
+          followers={artist.followers.total}
+        />
+      </div>
+      <div className="flex flex-wrap justify-center gap-2 sm:gap-5 mt-2 mb-10 px-2 xm:px-4">
+        {artist.genres.map((genre) => (
+          <span
+            key={genre}
+            className="bg-zinc-300 text-black px-5 py-2 rounded-md text-sm"
+          >
+            {genre}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default OverviewSection;

--- a/src/features/artist/components/RelatedArtistsTab.tsx
+++ b/src/features/artist/components/RelatedArtistsTab.tsx
@@ -1,0 +1,53 @@
+import useRelatedArtists from "@/features/artist/queries/useRelatedArtists";
+import LoadingBar from "@/features/common/components/LoadingBar";
+import TImage from "@/features/common/components/TImage";
+import { useTranslation } from "next-i18next";
+import Link from "next/link";
+
+interface RelatedArtistsTabProps {
+  artistId: string;
+}
+
+const RelatedArtistsTab = ({ artistId }: RelatedArtistsTabProps) => {
+  const { t } = useTranslation(["artist"]);
+  const { data, isLoading, isError } = useRelatedArtists({
+    artistId,
+    enabled: true,
+  });
+
+  if (isLoading) return <LoadingBar />;
+  if (isError)
+    return <div className="text-red-500">{t("error.loading_related")}</div>;
+  if (!data?.artists.length)
+    return <div className="text-gray-400">{t("no_related")}</div>;
+
+  return (
+    <div>
+      <h2 className="text-2xl font-semibold text-white mb-4">
+        {t("related_artists")}
+      </h2>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {data.artists.map((artist) => (
+          <Link key={artist.id} href={`/artist/${artist.id}`}>
+            <div className="p-4 hover:bg-zinc-800 rounded-lg transition-colors">
+              <div className="relative w-full aspect-square mb-3">
+                <TImage
+                  imageUrl={artist.images[0]?.url}
+                  alt={artist.name}
+                  type="artist"
+                  size="w-full h-full"
+                  className="rounded-full"
+                />
+              </div>
+              <h3 className="font-medium text-white text-center truncate">
+                {artist.name}
+              </h3>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RelatedArtistsTab;

--- a/src/features/artist/components/TopTracksTab.tsx
+++ b/src/features/artist/components/TopTracksTab.tsx
@@ -21,6 +21,8 @@ const TopTracksTab = ({ tracks }: TopTracksTabProps) => {
     handleNext,
     handleClosePlayer,
     currentTrack,
+    disablePrevious,
+    disableNext,
   } = useArtistPlayer(tracks);
 
   return (
@@ -53,6 +55,8 @@ const TopTracksTab = ({ tracks }: TopTracksTabProps) => {
           volume={volume}
           setVolume={setVolume}
           enableClose
+          disablePrevious={disablePrevious}
+          disableNext={disableNext}
         />
       )}
     </div>

--- a/src/features/artist/components/TopTracksTab.tsx
+++ b/src/features/artist/components/TopTracksTab.tsx
@@ -1,0 +1,62 @@
+import TopTrackItem from "@/features/artist/components/TopTrackItem";
+import useArtistPlayer from "@/features/artist/hooks/useArtistPlayer";
+import AudioPlayer from "@/features/audio/components/AudioPlayer";
+import { SimplifiedTrack } from "@/types/album";
+import { useTranslation } from "react-i18next";
+
+interface TopTracksTabProps {
+  tracks: SimplifiedTrack[];
+}
+
+const TopTracksTab = ({ tracks }: TopTracksTabProps) => {
+  const { t } = useTranslation(["artist"]);
+  const {
+    currentTrackIndex,
+    isPlaying,
+    volume,
+    setVolume,
+    setIsPlaying,
+    handlePlay,
+    handlePrevious,
+    handleNext,
+    handleClosePlayer,
+    currentTrack,
+  } = useArtistPlayer(tracks);
+
+  return (
+    <div
+      className={`space-y-4 ${currentTrack ? "pb-60 md:pb-40 desktop:pb-20" : ""}`}
+    >
+      <h2 className="text-2xl font-semibold text-white mb-4">
+        {t("top_tracks")}
+      </h2>
+      <ul className="space-y-4">
+        {tracks.map((track, index) => (
+          <TopTrackItem
+            key={track.id}
+            index={index}
+            track={track}
+            onPlay={() => handlePlay(index)}
+            isCurrent={currentTrackIndex === index}
+            isPlaying={isPlaying}
+          />
+        ))}
+      </ul>
+      {currentTrack && (
+        <AudioPlayer
+          track={currentTrack}
+          isPlaying={isPlaying}
+          setIsPlaying={setIsPlaying}
+          onPrevious={handlePrevious}
+          onNext={handleNext}
+          onClose={handleClosePlayer}
+          volume={volume}
+          setVolume={setVolume}
+          enableClose
+        />
+      )}
+    </div>
+  );
+};
+
+export default TopTracksTab;

--- a/src/features/artist/hooks/useArtistPlayer.ts
+++ b/src/features/artist/hooks/useArtistPlayer.ts
@@ -1,7 +1,7 @@
-import { ArtistPageData } from "@/types/artist";
+import { SimplifiedTrack } from "@/types/album";
 import { useCallback, useEffect, useState } from "react";
 
-const useArtistPlayer = (data: ArtistPageData) => {
+const useArtistPlayer = (tracks: SimplifiedTrack[]) => {
   const [currentTrackIndex, setCurrentTrackIndex] = useState<number | null>(
     null,
   );
@@ -28,13 +28,13 @@ const useArtistPlayer = (data: ArtistPageData) => {
   }, [volume]);
 
   const getPlayableTracks = useCallback(() => {
-    return data.topTracks.tracks.reduce<number[]>((acc, track, index) => {
+    return tracks.reduce<number[]>((acc, track, index) => {
       if (track.previewUrl) {
         acc.push(index);
       }
       return acc;
     }, []);
-  }, [data.topTracks.tracks]);
+  }, [tracks]);
 
   const findNextPlayableTrack = useCallback(
     (currentIndex: number) => {
@@ -93,9 +93,7 @@ const useArtistPlayer = (data: ArtistPageData) => {
   };
 
   const currentTrack =
-    currentTrackIndex !== null
-      ? data.topTracks.tracks[currentTrackIndex]
-      : null;
+    currentTrackIndex !== null ? tracks[currentTrackIndex] : null;
 
   return {
     currentTrackIndex,

--- a/src/features/artist/hooks/useArtistPlayer.ts
+++ b/src/features/artist/hooks/useArtistPlayer.ts
@@ -42,7 +42,10 @@ const useArtistPlayer = (tracks: SimplifiedTrack[]) => {
       const currentPlayableIndex = playableTracks.findIndex(
         (index) => index === currentIndex,
       );
-      return playableTracks[currentPlayableIndex + 1];
+      // 다음 재생 가능한 트랙이 없으면 undefined 반환
+      return currentPlayableIndex < playableTracks.length - 1
+        ? playableTracks[currentPlayableIndex + 1]
+        : undefined;
     },
     [getPlayableTracks],
   );
@@ -53,10 +56,32 @@ const useArtistPlayer = (tracks: SimplifiedTrack[]) => {
       const currentPlayableIndex = playableTracks.findIndex(
         (index) => index === currentIndex,
       );
-      return playableTracks[currentPlayableIndex - 1];
+      // 이전 재생 가능한 트랙이 없으면 undefined 반환
+      return currentPlayableIndex > 0
+        ? playableTracks[currentPlayableIndex - 1]
+        : undefined;
     },
     [getPlayableTracks],
   );
+
+  const getNavigationState = useCallback(() => {
+    if (currentTrackIndex === null) {
+      return { disablePrevious: true, disableNext: true };
+    }
+
+    const playableTracks = getPlayableTracks();
+    const currentPlayableIndex = playableTracks.findIndex(
+      (index) => index === currentTrackIndex,
+    );
+
+    // 재생 가능한 트랙 목록 내에서의 위치를 확인
+    return {
+      disablePrevious: currentPlayableIndex <= 0,
+      disableNext:
+        currentPlayableIndex >= playableTracks.length - 1 ||
+        findNextPlayableTrack(currentTrackIndex) === undefined,
+    };
+  }, [currentTrackIndex, getPlayableTracks, findNextPlayableTrack]);
 
   const handlePlay = (index: number) => {
     if (currentTrackIndex === index) {
@@ -94,6 +119,7 @@ const useArtistPlayer = (tracks: SimplifiedTrack[]) => {
 
   const currentTrack =
     currentTrackIndex !== null ? tracks[currentTrackIndex] : null;
+  const { disablePrevious, disableNext } = getNavigationState();
 
   return {
     currentTrackIndex,
@@ -106,6 +132,8 @@ const useArtistPlayer = (tracks: SimplifiedTrack[]) => {
     handleNext,
     handleClosePlayer,
     currentTrack,
+    disablePrevious,
+    disableNext,
   };
 };
 

--- a/src/features/artist/queries/useArtistAlbums.ts
+++ b/src/features/artist/queries/useArtistAlbums.ts
@@ -1,0 +1,51 @@
+import { ArtistAlbumsResponse } from "@/types/artist";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+interface UseArtistAlbumsProps {
+  artistId: string;
+  enabled?: boolean;
+}
+
+const fetchArtistAlbums = async ({
+  pageParam = 0,
+  queryKey,
+}: {
+  pageParam?: number;
+  queryKey: readonly ["artist-albums", string];
+}): Promise<ArtistAlbumsResponse> => {
+  const [, artistId] = queryKey;
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  const response = await axios.get<ArtistAlbumsResponse>(
+    `${baseUrl}/api/artist/${artistId}/albums`,
+    {
+      params: {
+        limit: 20,
+        offset: pageParam,
+      },
+    },
+  );
+
+  return response.data;
+};
+
+const useArtistAlbums = ({
+  artistId,
+  enabled = true,
+}: UseArtistAlbumsProps) => {
+  return useInfiniteQuery({
+    queryKey: ["artist-albums", artistId] as const,
+    queryFn: fetchArtistAlbums,
+    enabled,
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.next) {
+        return lastPage.offset + lastPage.limit;
+      }
+      return undefined;
+    },
+  });
+};
+
+export default useArtistAlbums;

--- a/src/features/artist/queries/useRelatedArtists.ts
+++ b/src/features/artist/queries/useRelatedArtists.ts
@@ -1,0 +1,31 @@
+import { SpotifyRelatedArtists } from "@/types/artist";
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+interface UseRelatedArtistsProps {
+  artistId: string;
+  enabled?: boolean;
+}
+
+const fetchRelatedArtists = async (
+  artistId: string,
+): Promise<SpotifyRelatedArtists> => {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const response = await axios.get<SpotifyRelatedArtists>(
+    `${baseUrl}/api/artist/${artistId}/related`,
+  );
+  return response.data;
+};
+
+const useRelatedArtists = ({
+  artistId,
+  enabled = true,
+}: UseRelatedArtistsProps) => {
+  return useQuery({
+    queryKey: ["related-artists", artistId],
+    queryFn: () => fetchRelatedArtists(artistId),
+    enabled,
+  });
+};
+
+export default useRelatedArtists;

--- a/src/features/audio/components/AudioPlayer.tsx
+++ b/src/features/audio/components/AudioPlayer.tsx
@@ -17,6 +17,8 @@ const AudioPlayerComponent = ({
   volume,
   setVolume,
   enableClose,
+  disablePrevious,
+  disableNext,
 }: AudioPlayerProps) => {
   const audioElementRef = useRef<AudioElementHandle | null>(null);
 
@@ -64,8 +66,8 @@ const AudioPlayerComponent = ({
         onPlayPause={() => setIsPlaying(!isPlaying)}
         onPrevious={onPrevious}
         onNext={onNext}
-        disablePrevious={false} // 필요에 따라 비활성화 로직 추가
-        disableNext={false} // 필요에 따라 비활성화 로직 추가
+        disablePrevious={disablePrevious}
+        disableNext={disableNext}
       />
 
       {/* 시크 바 및 볼륨 조절 */}

--- a/src/features/audio/components/PlaybackControls.tsx
+++ b/src/features/audio/components/PlaybackControls.tsx
@@ -17,7 +17,12 @@ const PlaybackControls = ({
       {/* 이전 버튼 */}
       <button
         onClick={onPrevious}
-        className="text-gray-400 hover:text-gray-300 focus:outline-none"
+        className={`text-gray-400 focus:outline-none transition-all duration-200
+          ${
+            disablePrevious
+              ? "opacity-30 cursor-not-allowed"
+              : "hover:text-gray-300"
+          }`}
         disabled={disablePrevious}
         type="button"
         aria-label="Previous Track"
@@ -45,7 +50,12 @@ const PlaybackControls = ({
       {/* 다음 버튼 */}
       <button
         onClick={onNext}
-        className="text-gray-400 hover:text-gray-300 focus:outline-none"
+        className={`text-gray-400 focus:outline-none transition-all duration-200
+          ${
+            disableNext
+              ? "opacity-30 cursor-not-allowed"
+              : "hover:text-gray-300"
+          }`}
         disabled={disableNext}
         type="button"
         aria-label="Next Track"

--- a/src/pages/api/artist/[artistId]/albums.ts
+++ b/src/pages/api/artist/[artistId]/albums.ts
@@ -1,0 +1,60 @@
+import getServerAxiosInstance from "@/libs/axios/axiosServerInstance";
+import withErrorHandling from "@/libs/utils/errorHandler";
+import { ArtistAlbumsResponse } from "@/types/artist";
+import { SpotifyAPIError, ValidationError } from "@/types/error";
+import { NextApiRequest, NextApiResponse } from "next";
+
+const validateArtistId = (artistId: unknown): string => {
+  if (!artistId || typeof artistId !== "string") {
+    throw new ValidationError("Invalid or missing artistId");
+  }
+
+  if (!artistId.match(/^[0-9A-Za-z]{22}$/)) {
+    throw new ValidationError("Invalid Spotify artist ID format");
+  }
+
+  return artistId;
+};
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<ArtistAlbumsResponse>,
+) => {
+  if (req.method !== "GET") {
+    throw new ValidationError("Method not allowed");
+  }
+
+  const { artistId } = req.query;
+  const { limit = "10", offset = "0" } = req.query;
+
+  const validatedArtistId = validateArtistId(artistId);
+  const parsedLimit = Math.min(50, Math.max(1, Number(limit)));
+  const parsedOffset = Math.max(0, Number(offset));
+
+  try {
+    const serverAxios = getServerAxiosInstance(req, res);
+    const response = await serverAxios.get(
+      `/artists/${validatedArtistId}/albums`,
+      {
+        params: {
+          limit: parsedLimit,
+          offset: parsedOffset,
+          market: process.env.SPOTIFY_MARKET || "US",
+        },
+      },
+    );
+
+    return res.status(200).json(response.data);
+  } catch (error) {
+    if (error instanceof ValidationError || error instanceof SpotifyAPIError) {
+      throw error;
+    }
+
+    throw new SpotifyAPIError(
+      "An unexpected error occurred while fetching artist albums",
+      500,
+    );
+  }
+};
+
+export default withErrorHandling(handler);

--- a/src/pages/api/artist/[artistId]/related.ts
+++ b/src/pages/api/artist/[artistId]/related.ts
@@ -1,0 +1,48 @@
+import getServerAxiosInstance from "@/libs/axios/axiosServerInstance";
+import withErrorHandling from "@/libs/utils/errorHandler";
+import { SpotifyRelatedArtists } from "@/types/artist";
+import { SpotifyAPIError, ValidationError } from "@/types/error";
+import { NextApiRequest, NextApiResponse } from "next";
+
+const validateArtistId = (artistId: unknown): string => {
+  if (!artistId || typeof artistId !== "string") {
+    throw new ValidationError("Invalid or missing artistId");
+  }
+
+  if (!artistId.match(/^[0-9A-Za-z]{22}$/)) {
+    throw new ValidationError("Invalid Spotify artist ID format");
+  }
+
+  return artistId;
+};
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<SpotifyRelatedArtists>,
+) => {
+  if (req.method !== "GET") {
+    throw new ValidationError("Method not allowed");
+  }
+
+  const { artistId } = req.query;
+  const validatedArtistId = validateArtistId(artistId);
+
+  try {
+    const serverAxios = getServerAxiosInstance(req, res);
+    const response = await serverAxios.get(
+      `/artists/${validatedArtistId}/related-artists`,
+    );
+    return res.status(200).json(response.data);
+  } catch (error) {
+    if (error instanceof ValidationError || error instanceof SpotifyAPIError) {
+      throw error;
+    }
+
+    throw new SpotifyAPIError(
+      "An unexpected error occurred while fetching artist albums",
+      500,
+    );
+  }
+};
+
+export default withErrorHandling(handler);

--- a/src/pages/artist/[artistId].tsx
+++ b/src/pages/artist/[artistId].tsx
@@ -34,7 +34,7 @@ const ArtistPage = ({ artistId }: ArtistPageProps) => {
   return (
     <div className="max-w-4xl mx-auto p-6 mt-6 bg-zinc-800 rounded-lg shadow-md">
       <ArtistSEO data={data} artistId={artistId} />
-      <ArtistSection data={data} />
+      <ArtistSection data={data} artistId={artistId} />
     </div>
   );
 };

--- a/src/types/album.ts
+++ b/src/types/album.ts
@@ -90,6 +90,8 @@ export interface AudioPlayerProps {
   volume: number;
   setVolume: (volume: number) => void;
   enableClose: boolean;
+  disablePrevious?: boolean;
+  disableNext?: boolean;
 }
 
 export interface PlaybackControlsProps {

--- a/src/types/artist.ts
+++ b/src/types/artist.ts
@@ -1,4 +1,4 @@
-import { SimplifiedTrack } from "@/types/album";
+import { SimplifiedTrack, SpotifyAlbum } from "@/types/album";
 import { Artist, ArtistRanking, Track, TrackRanking } from "@prisma/client";
 
 export type RankingCategory =
@@ -110,6 +110,16 @@ export interface CombinedArtistData {
 
 export type ArtistResponseData = CombinedArtistData;
 
+export interface ArtistAlbumsResponse {
+  href: string;
+  limit: number;
+  next: string | null;
+  offset: number;
+  previous: string | null;
+  total: number;
+  items: SpotifyAlbum[];
+}
+
 export interface ArtistPageData {
   artist: {
     id: string;
@@ -123,13 +133,6 @@ export interface ArtistPageData {
   };
   topTracks: {
     tracks: SimplifiedTrack[];
-  };
-  relatedArtists: {
-    artists: {
-      id: string;
-      name: string;
-      images: { url: string }[];
-    }[];
   };
 }
 


### PR DESCRIPTION
1. [Feat: 아티스트 페이지에서 인기 트랙, 앨범, 연관 아티스트를 탭별로 보여주도록 변경](https://github.com/jihohub/track-list-now/commit/6a7267ef125b3f9080526505e87accb9163ca50e)
2. [Feat: AudioPlayer 컴포넌트 이전 트랙, 다음 트랙 체크 로직 강화](https://github.com/jihohub/track-list-now/commit/f84425388190c925b9fe258a74e9b3766ce78439)