### PR TITLE
Fix: 아티스트 페이지에서 언어 변경시 선택한 탭이 유지되지 않고 인기 트랙 탭으로 바뀌는 현상 수정

### DIFF
--- a/src/features/artist/components/ArtistSection.tsx
+++ b/src/features/artist/components/ArtistSection.tsx
@@ -3,8 +3,9 @@ import ArtistTabs from "@/features/artist/components/ArtistTabs";
 import OverviewSection from "@/features/artist/components/OverviewSection";
 import RelatedArtistsTab from "@/features/artist/components/RelatedArtistsTab";
 import TopTracksTab from "@/features/artist/components/TopTracksTab";
+import useArtistTabs from "@/features/artist/hooks/useArtistTabs";
+import LoadingBar from "@/features/common/components/LoadingBar";
 import { ArtistPageData } from "@/types/artist";
-import { useRouter } from "next/router";
 
 interface ArtistSectionProps {
   data: ArtistPageData;
@@ -12,23 +13,14 @@ interface ArtistSectionProps {
 }
 
 const ArtistSection = ({ data, artistId }: ArtistSectionProps) => {
-  const router = useRouter();
-  const { tab = "top_tracks" } = router.query;
+  const { currentTab, handleTabChange, isReady } = useArtistTabs();
 
-  const handleTabChange = (newTab: string) => {
-    const query = { ...router.query, tab: newTab };
-    router.push(
-      {
-        pathname: router.pathname,
-        query,
-      },
-      undefined,
-      { shallow: true },
-    );
-  };
+  if (!isReady) {
+    return <LoadingBar />;
+  }
 
   const renderTabContent = () => {
-    switch (tab) {
+    switch (currentTab) {
       case "albums":
         return <AlbumsTab artistId={artistId} />;
       case "related_artists":
@@ -42,7 +34,7 @@ const ArtistSection = ({ data, artistId }: ArtistSectionProps) => {
   return (
     <div>
       <OverviewSection artist={data.artist} />
-      <ArtistTabs currentTab={tab as string} onTabChange={handleTabChange} />
+      <ArtistTabs currentTab={currentTab} onTabChange={handleTabChange} />
       <div className="mt-6">{renderTabContent()}</div>
     </div>
   );

--- a/src/features/artist/components/ArtistTabs.tsx
+++ b/src/features/artist/components/ArtistTabs.tsx
@@ -1,15 +1,16 @@
-// import TopTracksTab from "@/features/artist/components/TopTracksTab";
 import { useTranslation } from "next-i18next";
 
+type TabType = "top_tracks" | "albums" | "related_artists";
+
 interface ArtistTabsProps {
-  currentTab: string;
-  onTabChange: (tab: string) => void;
+  currentTab: TabType;
+  onTabChange: (tab: TabType) => void;
 }
 
 const ArtistTabs = ({ currentTab, onTabChange }: ArtistTabsProps) => {
   const { t } = useTranslation(["artist"]);
 
-  const tabs = [
+  const tabs: { label: string; value: TabType }[] = [
     { label: "top_tracks", value: "top_tracks" },
     { label: "albums", value: "albums" },
     { label: "related_artists", value: "related_artists" },

--- a/src/features/artist/hooks/useArtistTabs.ts
+++ b/src/features/artist/hooks/useArtistTabs.ts
@@ -1,0 +1,54 @@
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+type TabType = "top_tracks" | "albums" | "related_artists";
+
+interface UseArtistTabsProps {
+  defaultTab?: TabType;
+}
+
+const useArtistTabs = ({
+  defaultTab = "top_tracks",
+}: UseArtistTabsProps = {}) => {
+  const router = useRouter();
+
+  // 라우터가 준비되었을 때 초기 탭 설정
+  useEffect(() => {
+    if (!router.isReady) return;
+
+    if (!router.query.tab) {
+      router.push(
+        {
+          pathname: router.pathname,
+          query: { ...router.query, tab: defaultTab },
+        },
+        undefined,
+        { shallow: true },
+      );
+    }
+  }, [router.isReady, defaultTab]);
+
+  // 현재 활성화된 탭
+  const currentTab = (router.query.tab as TabType) || defaultTab;
+
+  // 탭 변경 핸들러
+  const handleTabChange = (newTab: TabType) => {
+    const query = { ...router.query, tab: newTab };
+    router.push(
+      {
+        pathname: router.pathname,
+        query,
+      },
+      undefined,
+      { shallow: true },
+    );
+  };
+
+  return {
+    currentTab,
+    handleTabChange,
+    isReady: router.isReady,
+  };
+};
+
+export default useArtistTabs;

--- a/src/features/artist/hooks/useArtistTabs.ts
+++ b/src/features/artist/hooks/useArtistTabs.ts
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 
 type TabType = "top_tracks" | "albums" | "related_artists";
 
@@ -11,38 +11,43 @@ const useArtistTabs = ({
   defaultTab = "top_tracks",
 }: UseArtistTabsProps = {}) => {
   const router = useRouter();
+  const { isReady, pathname, query } = router;
 
-  // 라우터가 준비되었을 때 초기 탭 설정
-  useEffect(() => {
-    if (!router.isReady) return;
-
-    if (!router.query.tab) {
+  const setInitialTab = useCallback(() => {
+    if (!query.tab) {
       router.push(
         {
-          pathname: router.pathname,
-          query: { ...router.query, tab: defaultTab },
+          pathname,
+          query: { ...query, tab: defaultTab },
         },
         undefined,
         { shallow: true },
       );
     }
-  }, [router.isReady, defaultTab]);
+  }, [pathname, query, defaultTab, router]);
 
-  // 현재 활성화된 탭
-  const currentTab = (router.query.tab as TabType) || defaultTab;
+  // 라우터가 준비되었을 때 초기 탭 설정
+  useEffect(() => {
+    if (!isReady) return;
+    setInitialTab();
+  }, [isReady, setInitialTab]);
 
   // 탭 변경 핸들러
-  const handleTabChange = (newTab: TabType) => {
-    const query = { ...router.query, tab: newTab };
-    router.push(
-      {
-        pathname: router.pathname,
-        query,
-      },
-      undefined,
-      { shallow: true },
-    );
-  };
+  const handleTabChange = useCallback(
+    (newTab: TabType) => {
+      router.push(
+        {
+          pathname,
+          query: { ...query, tab: newTab },
+        },
+        undefined,
+        { shallow: true },
+      );
+    },
+    [pathname, query, router],
+  );
+
+  const currentTab = (query.tab as TabType) || defaultTab;
 
   return {
     currentTab,

--- a/src/features/audio/components/SeekBar.tsx
+++ b/src/features/audio/components/SeekBar.tsx
@@ -22,6 +22,7 @@ const SeekBar = ({ currentTime, duration, onSeek }: SeekBarProps) => {
       <input
         type="range"
         min="0"
+        step={duration > currentTime ? 1 : 0.5}
         max={duration}
         value={currentTime}
         onChange={(e) => onSeek(Number(e.target.value))}

--- a/src/features/common/components/LanguageToggle.tsx
+++ b/src/features/common/components/LanguageToggle.tsx
@@ -1,22 +1,30 @@
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const LanguageToggle = () => {
   const router = useRouter();
   const [isKorean, setIsKorean] = useState(router.locale === "ko"); // 현재 locale에 맞춰 초기 값 설정
 
   const changeLanguage = (lang: string) => {
-    if (router.locale !== lang) {
-      router.push(router.pathname, router.asPath, { locale: lang });
-    }
+    if (router.locale === lang) return;
+
+    // 현재 URL을 그대로 사용하면서 locale만 변경
+    const { pathname, query, asPath } = router;
+
+    router.push({ pathname, query }, asPath, {
+      locale: lang,
+      shallow: true,
+      scroll: false, // 페이지 스크롤 위치 유지
+    });
   };
 
+  useEffect(() => {
+    setIsKorean(router.locale === "ko");
+  }, [router.locale]);
+
   const handleToggle = () => {
-    setIsKorean((prevIsKorean) => {
-      const newLang = !prevIsKorean ? "ko" : "en";
-      changeLanguage(newLang);
-      return !prevIsKorean;
-    });
+    const newLang = !isKorean ? "ko" : "en";
+    changeLanguage(newLang);
   };
 
   return (

--- a/src/pages/artist/[artistId].tsx
+++ b/src/pages/artist/[artistId].tsx
@@ -44,6 +44,7 @@ export default ArtistPage;
 export const getServerSideProps: GetServerSideProps = async ({
   locale,
   params,
+  query,
 }) => {
   const queryClient = new QueryClient();
   const artistId = params?.artistId as string;
@@ -64,6 +65,7 @@ export const getServerSideProps: GetServerSideProps = async ({
         ])),
         dehydratedState: dehydrate(queryClient),
         artistId,
+        defaultTab: query.tab || "top_tracks",
       },
     };
   } catch (error) {
@@ -78,6 +80,7 @@ export const getServerSideProps: GetServerSideProps = async ({
         ])),
         dehydratedState: dehydrate(queryClient),
         artistId,
+        defaultTab: "top_tracks",
       },
     };
   }


### PR DESCRIPTION
1. [Fix: 아티스트 페이지에서 언어 변경시 선택한 탭이 유지되지 않고 인기 트랙 탭으로 바뀌는 현상 수정](https://github.com/jihohub/track-list-now/commit/71d3024f40736d4ca8804ebff3c008b6ab33b387)
2. [Fix: 아티스트 페이지 라우터가 준비되었을 때 초기 탭 설정하도록 수정](https://github.com/jihohub/track-list-now/commit/a5631ce0511b161a1d9ebfa864167548f20f03e4)
3. [Fix: 미리듣기가 끝까지 재생됐을 때 시크바의 영역이 100% 채워지지 않는 현상 수정](https://github.com/jihohub/track-list-now/commit/0525086bb439bf934a28eb7df6e2ed59b826e3b5)