### PR TITLE
Fix: 아티스트 페이지에서 언어 변경해도 탭 유지하도록 수정

### DIFF
--- a/src/features/artist/components/ArtistSection.tsx
+++ b/src/features/artist/components/ArtistSection.tsx
@@ -4,7 +4,6 @@ import OverviewSection from "@/features/artist/components/OverviewSection";
 import RelatedArtistsTab from "@/features/artist/components/RelatedArtistsTab";
 import TopTracksTab from "@/features/artist/components/TopTracksTab";
 import useArtistTabs from "@/features/artist/hooks/useArtistTabs";
-import LoadingBar from "@/features/common/components/LoadingBar";
 import { ArtistPageData } from "@/types/artist";
 
 interface ArtistSectionProps {
@@ -13,11 +12,7 @@ interface ArtistSectionProps {
 }
 
 const ArtistSection = ({ data, artistId }: ArtistSectionProps) => {
-  const { currentTab, handleTabChange, isReady } = useArtistTabs();
-
-  if (!isReady) {
-    return <LoadingBar />;
-  }
+  const { currentTab, setCurrentTab } = useArtistTabs();
 
   const renderTabContent = () => {
     switch (currentTab) {
@@ -34,7 +29,7 @@ const ArtistSection = ({ data, artistId }: ArtistSectionProps) => {
   return (
     <div>
       <OverviewSection artist={data.artist} />
-      <ArtistTabs currentTab={currentTab} onTabChange={handleTabChange} />
+      <ArtistTabs currentTab={currentTab} setCurrentTab={setCurrentTab} />
       <div className="mt-6">{renderTabContent()}</div>
     </div>
   );

--- a/src/features/artist/components/ArtistTabs.tsx
+++ b/src/features/artist/components/ArtistTabs.tsx
@@ -1,16 +1,14 @@
 import { useTranslation } from "next-i18next";
 
-type TabType = "top_tracks" | "albums" | "related_artists";
-
 interface ArtistTabsProps {
-  currentTab: TabType;
-  onTabChange: (tab: TabType) => void;
+  currentTab: string;
+  setCurrentTab: (tab: string) => void;
 }
 
-const ArtistTabs = ({ currentTab, onTabChange }: ArtistTabsProps) => {
+const ArtistTabs = ({ currentTab, setCurrentTab }: ArtistTabsProps) => {
   const { t } = useTranslation(["artist"]);
 
-  const tabs: { label: string; value: TabType }[] = [
+  const tabs: { label: string; value: string }[] = [
     { label: "top_tracks", value: "top_tracks" },
     { label: "albums", value: "albums" },
     { label: "related_artists", value: "related_artists" },
@@ -21,7 +19,7 @@ const ArtistTabs = ({ currentTab, onTabChange }: ArtistTabsProps) => {
       {tabs.map((tab) => (
         <button
           key={tab.value}
-          onClick={() => onTabChange(tab.value)}
+          onClick={() => setCurrentTab(tab.value)}
           className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
             currentTab === tab.value
               ? "bg-persianBlue text-white"

--- a/src/features/artist/hooks/useArtistTabs.ts
+++ b/src/features/artist/hooks/useArtistTabs.ts
@@ -1,58 +1,16 @@
 import { useRouter } from "next/router";
-import { useCallback, useEffect } from "react";
+import { useState } from "react";
 
-type TabType = "top_tracks" | "albums" | "related_artists";
-
-interface UseArtistTabsProps {
-  defaultTab?: TabType;
-}
-
-const useArtistTabs = ({
-  defaultTab = "top_tracks",
-}: UseArtistTabsProps = {}) => {
+const useArtistTabs = () => {
   const router = useRouter();
-  const { isReady, pathname, query } = router;
-
-  const setInitialTab = useCallback(() => {
-    if (!query.tab) {
-      router.push(
-        {
-          pathname,
-          query: { ...query, tab: defaultTab },
-        },
-        undefined,
-        { shallow: true },
-      );
-    }
-  }, [pathname, query, defaultTab, router]);
-
-  // 라우터가 준비되었을 때 초기 탭 설정
-  useEffect(() => {
-    if (!isReady) return;
-    setInitialTab();
-  }, [isReady, setInitialTab]);
-
-  // 탭 변경 핸들러
-  const handleTabChange = useCallback(
-    (newTab: TabType) => {
-      router.push(
-        {
-          pathname,
-          query: { ...query, tab: newTab },
-        },
-        undefined,
-        { shallow: true },
-      );
-    },
-    [pathname, query, router],
+  const { tab } = router.query;
+  const [currentTab, setCurrentTab] = useState<string>(
+    typeof tab === "string" ? tab : "top_tracks",
   );
-
-  const currentTab = (query.tab as TabType) || defaultTab;
 
   return {
     currentTab,
-    handleTabChange,
-    isReady: router.isReady,
+    setCurrentTab,
   };
 };
 

--- a/src/features/common/components/LanguageToggle.tsx
+++ b/src/features/common/components/LanguageToggle.tsx
@@ -6,16 +6,9 @@ const LanguageToggle = () => {
   const [isKorean, setIsKorean] = useState(router.locale === "ko"); // 현재 locale에 맞춰 초기 값 설정
 
   const changeLanguage = (lang: string) => {
-    if (router.locale === lang) return;
-
-    // 현재 URL을 그대로 사용하면서 locale만 변경
-    const { pathname, query, asPath } = router;
-
-    router.push({ pathname, query }, asPath, {
-      locale: lang,
-      shallow: true,
-      scroll: false, // 페이지 스크롤 위치 유지
-    });
+    if (router.locale !== lang) {
+      router.push(router.pathname, router.asPath, { locale: lang });
+    }
   };
 
   const handleToggle = () => {


### PR DESCRIPTION
1. [Fix: 아티스트 페이지에서 언어 변경해도 탭 유지하도록 수정](https://github.com/jihohub/track-list-now/commit/2da0a36e0a1936edff293cad425b3aa59c80b0b1)