### PR TITLE
Fix: 스포티파이 artist API related-artist 기능 deprecated로 인해 연관 아티스트 탭 삭제

### DIFF
--- a/src/features/artist/components/ArtistSection.tsx
+++ b/src/features/artist/components/ArtistSection.tsx
@@ -1,7 +1,6 @@
 import AlbumsTab from "@/features/artist/components/AlbumsTab";
 import ArtistTabs from "@/features/artist/components/ArtistTabs";
 import OverviewSection from "@/features/artist/components/OverviewSection";
-import RelatedArtistsTab from "@/features/artist/components/RelatedArtistsTab";
 import TopTracksTab from "@/features/artist/components/TopTracksTab";
 import useArtistTabs from "@/features/artist/hooks/useArtistTabs";
 import { ArtistPageData } from "@/types/artist";
@@ -18,8 +17,8 @@ const ArtistSection = ({ data, artistId }: ArtistSectionProps) => {
     switch (currentTab) {
       case "albums":
         return <AlbumsTab artistId={artistId} />;
-      case "related_artists":
-        return <RelatedArtistsTab artistId={artistId} />;
+      // case "related_artists":
+      //   return <RelatedArtistsTab artistId={artistId} />;
       case "top_tracks":
       default:
         return <TopTracksTab tracks={data.topTracks.tracks} />;

--- a/src/features/artist/components/ArtistTabs.tsx
+++ b/src/features/artist/components/ArtistTabs.tsx
@@ -11,7 +11,7 @@ const ArtistTabs = ({ currentTab, setCurrentTab }: ArtistTabsProps) => {
   const tabs: { label: string; value: string }[] = [
     { label: "top_tracks", value: "top_tracks" },
     { label: "albums", value: "albums" },
-    { label: "related_artists", value: "related_artists" },
+    // { label: "related_artists", value: "related_artists" },
   ];
 
   return (


### PR DESCRIPTION
1. [Fix: 스포티파이 artist API related-artist 기능 deprecated로 인해 연관 아티스트 탭 삭제](https://github.com/jihohub/track-list-now/commit/5386517bf7032e85bf7ba748d0f0dd9f489aea1b)